### PR TITLE
Implement `aria-controls` accessibility attribute

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -320,6 +320,13 @@ public extension Node where Context: HTML.BodyContext {
     static func ariaLabel(_ label: String) -> Node {
         .attribute(named: "aria-label", value: label)
     }
+    
+    /// Assign an accessibility attribute to an element,
+    /// to establish a parent -> child relationship
+    /// - parameter child: The child to assign to the parent
+    static func ariaControls(_ child: String) -> Node {
+        .attribute(named: "aria-controls", value: child)
+    }
 }
 
 // MARK: - Other, element-specific attributes

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -483,6 +483,15 @@ final class HTMLTests: XCTestCase {
         let html = HTML(.body(.button(.text("X"), .ariaLabel("Close"))))
         assertEqualHTMLContent(html, #"<body><button aria-label="Close">X</button></body>"#)
     }
+    
+    func testAccessibilityControls() {
+        let html = HTML(.body(.ul(.li(.id("list"), .ariaControls("div"))), .div(.id("div"))))
+        assertEqualHTMLContent(html, """
+        <body>\
+        <ul><li id="list" aria-controls="div"></li></ul><div id="div"></div>\
+        </body>
+        """)
+    }
 
     func testDataAttributes() {
         let html = HTML(.body(
@@ -550,6 +559,7 @@ extension HTMLTests {
             ("testNavigation", testNavigation),
             ("testSection", testSection),
             ("testAccessibilityLabel", testAccessibilityLabel),
+            ("testAccessibilityControls", testAccessibilityControls),
             ("testDataAttributes", testDataAttributes),
             ("testComments", testComments)
         ]


### PR DESCRIPTION
This implements the `aria-controls` attribute which is used to establish parent -> child relationship between nodes.

https://www.w3.org/TR/wai-aria-1.1/#aria-controls
https://www.accessibilityresources.org/aria-controls
