### PR TITLE
HTML: Unit test <th> element

### DIFF
--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -182,12 +182,17 @@ final class HTMLTests: XCTestCase {
         let html = HTML(.body(
             .table(
                 .caption("Caption"),
-                .tr(.td("Hello"))
+                .tr(.th("Hello")),
+                .tr(.td("World"))
             )
         ))
 
         assertEqualHTMLContent(html, """
-        <body><table><caption>Caption</caption><tr><td>Hello</td></tr></table></body>
+        <body><table>\
+        <caption>Caption</caption>\
+        <tr><th>Hello</th></tr>\
+        <tr><td>World</td></tr>\
+        </table></body>
         """)
     }
 


### PR DESCRIPTION
Turns out the only test covering this element was deleted before public release, so make `testTable` also cover `<th>` to restore 100% coverage.