### PR TITLE
Implement `aria-expanded` accessibility attribute

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -327,6 +327,13 @@ public extension Node where Context: HTML.BodyContext {
     static func ariaControls(_ child: String) -> Node {
         .attribute(named: "aria-controls", value: child)
     }
+    
+    /// Assign an accessibility attribute to an element,
+    /// which describes whether the element is expanded or not
+    /// - parameter isExpanded: Whether the element is expanded or not
+    static func ariaExpanded(_ isExpanded: Bool) -> Node {
+        .attribute(named: "aria-expanded", value: isExpanded ? "true" : "false")
+    }
 }
 
 // MARK: - Other, element-specific attributes

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -497,6 +497,11 @@ final class HTMLTests: XCTestCase {
         </body>
         """)
     }
+    
+    func testAccessibilityExpanded() {
+        let html = HTML(.body(.a(.ariaExpanded(true))))
+        assertEqualHTMLContent(html, #"<body><a aria-expanded="true"></a></body>"#)
+    }
 
     func testDataAttributes() {
         let html = HTML(.body(
@@ -565,6 +570,7 @@ extension HTMLTests {
             ("testSection", testSection),
             ("testAccessibilityLabel", testAccessibilityLabel),
             ("testAccessibilityControls", testAccessibilityControls),
+            ("testAccessibilityExpanded", testAccessibilityExpanded),
             ("testDataAttributes", testDataAttributes),
             ("testComments", testComments)
         ]


### PR DESCRIPTION
And the `aria` aria saga continues…

I'm using this one on my site to determine whether a css-only menu is in it's expanded state or not. By using this I was able to leverage the power of responsiveness™  and remove the last pieces of JavaScript on the site.

Reference: 

https://www.w3.org/WAI/GL/wiki/Using_aria-expanded_to_indicate_the_state_of_a_collapsible_element