### PR TITLE
Enable URLs to be passed directly to attributes and components

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -116,16 +116,16 @@ public extension Attribute where Context == HTML.LinkContext {
 public extension Attribute where Context: HTMLLinkableContext {
     /// Assign a URL to link the element to, using its `href` attribute.
     /// - parameter url: The URL to assign.
-    static func href(_ url: String) -> Attribute {
-        Attribute(name: "href", value: url)
+    static func href(_ url: URLRepresentable) -> Attribute {
+        Attribute(name: "href", value: url.string)
     }
 }
 
 public extension Node where Context: HTMLLinkableContext {
     /// Assign a URL to link the element to, using its `href` attribute.
     /// - parameter url: The URL to assign.
-    static func href(_ url: String) -> Node {
-        .attribute(named: "href", value: url)
+    static func href(_ url: URLRepresentable) -> Node {
+        .attribute(named: "href", value: url.string)
     }
 }
 
@@ -148,17 +148,17 @@ public extension Node where Context == HTML.AnchorContext {
 
 public extension Attribute where Context: HTMLSourceContext {
     /// Assign a source to the element, using its `src` attribute.
-    /// - parameter source: The source URL to assign.
-    static func src(_ source: String) -> Attribute {
-        Attribute(name: "src", value: source)
+    /// - parameter url: The source URL to assign.
+    static func src(_ url: URLRepresentable) -> Attribute {
+        Attribute(name: "src", value: url.string)
     }
 }
 
 public extension Node where Context: HTMLSourceContext {
     /// Assign a source to the element, using its `src` attribute.
-    /// - parameter source: The source URL to assign.
-    static func src(_ source: String) -> Node {
-        .attribute(named: "src", value: source)
+    /// - parameter url: The source URL to assign.
+    static func src(_ url: URLRepresentable) -> Node {
+        .attribute(named: "src", value: url.string)
     }
 }
 
@@ -191,8 +191,8 @@ public extension Attribute where Context == HTML.VideoSourceContext {
 public extension Node where Context == HTML.FormContext {
     /// Assign a URL that this form should be sent to when submitted.
     /// - parameter url: The action URL that the form should be sent to.
-    static func action(_ url: String) -> Node {
-        .attribute(named: "action", value: url)
+    static func action(_ url: URLRepresentable) -> Node {
+        .attribute(named: "action", value: url.string)
     }
 }
 

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -13,14 +13,16 @@ public extension Node where Context == HTML.HeadContext {
 
     /// Link the HTML page to an external CSS stylesheet.
     /// - parameter url: The URL of the stylesheet to link to.
-    static func stylesheet(_ url: String) -> Node {
-        .link(.rel(.stylesheet), .href(url), .type("text/css"))
+    static func stylesheet(_ url: URLRepresentable) -> Node {
+        .link(.rel(.stylesheet), .href(url.string), .type("text/css"))
     }
 
     /// Declare the HTML page's canonical URL, for social sharing and SEO.
     /// - parameter url: The URL to declare as this document's canonical URL.
-    static func url(_ url: String) -> Node {
-        .group([
+    static func url(_ url: URLRepresentable) -> Node {
+        let url = url.string
+
+        return .group([
             .link(.rel(.canonical), .href(url)),
             .meta(.name("twitter:url"), .content(url)),
             .meta(.name("og:url"), .content(url))
@@ -56,8 +58,10 @@ public extension Node where Context == HTML.HeadContext {
     /// Declare a URL to an image that should be displayed when the HTML page
     /// is shared on a social media website or app.
     /// - parameter url: The URL to declare. Should be an absolute URL.
-    static func socialImageLink(_ url: String) -> Node {
-        .group([
+    static func socialImageLink(_ url: URLRepresentable) -> Node {
+        let url = url.string
+
+        return .group([
             .meta(.name("twitter:image"), .content(url)),
             .meta(.name("og:image"), .content(url))
         ])
@@ -86,18 +90,18 @@ public extension Node where Context == HTML.HeadContext {
     /// title in various browser UIs) for the HTML page.
     /// - parameter url: The favicon's URL.
     /// - parameter type: The MIME type of the image (default: "image/png").
-    static func favicon(_ url: String, type: String = "image/png") -> Node {
-        .link(.rel(.shortcutIcon), .href(url), .type(type))
+    static func favicon(_ url: URLRepresentable, type: String = "image/png") -> Node {
+        .link(.rel(.shortcutIcon), .href(url.string), .type(type))
     }
 
     /// Declare a url to an RSS feed to associate with this HTML page.
     /// - parameter url: The URL to the RSS feed.
     /// - parameter title: An optional title that some RSS readers will display
     ///   for the feed.
-    static func rssFeedLink(_ url: String, title: String? = nil) -> Node {
+    static func rssFeedLink(_ url: URLRepresentable, title: String? = nil) -> Node {
         .link(
             .rel(.alternate),
-            .href(url),
+            .href(url.string),
             .type("application/rss+xml"),
             .attribute(named: "title", value: title)
         )

--- a/Sources/Plot/API/PodcastAttributes.swift
+++ b/Sources/Plot/API/PodcastAttributes.swift
@@ -7,8 +7,8 @@
 public extension Attribute where Context == PodcastFeed.EnclosureContext {
     /// Assign an URL from which the enclosure's file can be downloaded.
     /// - parameter url: The URL to assign.
-    static func url(_ url: String) -> Attribute {
-        Attribute(name: "url", value: url)
+    static func url(_ url: URLRepresentable) -> Attribute {
+        Attribute(name: "url", value: url.string)
     }
 
     /// Assign a length to the enclosure, in terms of its file size.

--- a/Sources/Plot/API/PodcastComponents.swift
+++ b/Sources/Plot/API/PodcastComponents.swift
@@ -11,7 +11,7 @@ public extension Node where Context == PodcastFeed.ItemContext {
     /// - parameter byteSize: The size of the audio file in bytes.
     /// - parameter type: The MIME type of the audio (default: "audio/mpeg", or MP3).
     /// - parameter title: The title of the episode.
-    static func audio(url: String,
+    static func audio(url: URLRepresentable,
                       byteSize: Int,
                       type: String = "audio/mpeg",
                       title: String) -> Node {

--- a/Sources/Plot/API/PodcastElements.swift
+++ b/Sources/Plot/API/PodcastElements.swift
@@ -9,8 +9,8 @@
 public extension Node where Context == PodcastFeed.ChannelContext {
     /// Instruct Apple Podcasts that the podcast's feed has moved to a new URL.
     /// - parameter url: The feed's new URL.
-    static func newFeedURL(_ url: String) -> Node {
-        .element(named: "itunes:new-feed-url", text: url)
+    static func newFeedURL(_ url: URLRepresentable) -> Node {
+        .element(named: "itunes:new-feed-url", text: url.string)
     }
 
     /// Attach a copyright notice to the feed.
@@ -66,10 +66,10 @@ public extension Node where Context: PodcastContentContext {
 
     /// Associate an image with the content.
     /// - parameter url: The URL of the content's image.
-    static func image(_ url: String) -> Node {
+    static func image(_ url: URLRepresentable) -> Node {
         .selfClosedElement(
             named: "itunes:image",
-            attributes: [.any(name: "href", value: url)]
+            attributes: [.any(name: "href", value: url.string)]
         )
     }
 }
@@ -175,8 +175,8 @@ public extension Node where Context == PodcastFeed.ItemContext {
 public extension Node where Context == PodcastFeed.MediaContext {
     /// Assign an URL from which the media's file can be downloaded.
     /// - parameter url: The URL to assign.
-    static func url(_ url: String) -> Node {
-        .attribute(named: "url", value: url)
+    static func url(_ url: URLRepresentable) -> Node {
+        .attribute(named: "url", value: url.string)
     }
 
     /// Assign a length to the media item, in terms of its file size.

--- a/Sources/Plot/API/RSSAttributes.swift
+++ b/Sources/Plot/API/RSSAttributes.swift
@@ -14,8 +14,8 @@ public extension Node where Context: RSSFeedContext {
     /// Add a namespace to this RSS feed.
     /// - parameter name: The name of the namespace to add.
     /// - parameter url: The URL of the namespace's definition.
-    static func namespace(_ name: String, _ url: String) -> Node {
-        .attribute(named: "xmlns:\(name)", value: url)
+    static func namespace(_ name: String, _ url: URLRepresentable) -> Node {
+        .attribute(named: "xmlns:\(name)", value: url.string)
     }
 }
 

--- a/Sources/Plot/API/RSSElements.swift
+++ b/Sources/Plot/API/RSSElements.swift
@@ -60,9 +60,9 @@ public extension Node where Context: RSSChannelContext {
     /// Associate an Atom feed link with this feed.
     /// - parameter href: The link of the atom feed (usually the same URL as
     ///   the feed's own).
-    static func atomLink(_ href: String) -> Node {
+    static func atomLink(_ href: URLRepresentable) -> Node {
         .selfClosedElement(named: "atom:link", attributes: [
-            .any(name: "href", value: href),
+            .any(name: "href", value: href.string),
             .any(name: "rel", value: "self"),
             .any(name: "type", value: "application/rss+xml")
         ])
@@ -118,8 +118,8 @@ public extension Node where Context: RSSContentContext {
 
     /// Define the content's canonical URL.
     /// - parameter url: The content's URL.
-    static func link(_ url: String) -> Node {
-        .element(named: "link", text: url)
+    static func link(_ url: URLRepresentable) -> Node {
+        .element(named: "link", text: url.string)
     }
 
     /// Declare which date that the content was published on.

--- a/Sources/Plot/API/SiteMapElements.swift
+++ b/Sources/Plot/API/SiteMapElements.swift
@@ -43,8 +43,8 @@ public extension Node where Context == SiteMap.URLSetContext {
 public extension Node where Context == SiteMap.URLContext {
     /// Define the URL's location.
     /// - parameter url: The canonical location URL.
-    static func loc(_ url: String) -> Node {
-        .element(named: "loc", text: url)
+    static func loc(_ url: URLRepresentable) -> Node {
+        .element(named: "loc", text: url.string)
     }
 
     /// Define the frequency at which the URL's content is expected to change.

--- a/Sources/Plot/API/URLRepresentable.swift
+++ b/Sources/Plot/API/URLRepresentable.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Protocol adopted by types that can represent a URL, which
+/// can then be converted into a string using the `description`
+/// property. `URL` and `String` conforms to this protocol.
+public protocol URLRepresentable: CustomStringConvertible {}
+
+extension URL: URLRepresentable {}
+extension String: URLRepresentable {}
+
+internal extension URLRepresentable {
+    var string: String { description }
+}

--- a/Sources/Plot/API/URLRepresentable.swift
+++ b/Sources/Plot/API/URLRepresentable.swift
@@ -1,3 +1,9 @@
+/**
+*  Plot
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
 import Foundation
 
 /// Protocol adopted by types that can represent a URL, which

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -164,16 +164,18 @@ final class HTMLTests: XCTestCase {
         """)
     }
 
-    func testAnchors() {
-        let html = HTML(.body(
+    func testAnchors() throws {
+        let html = try HTML(.body(
             .a(.href("a.html"), .target(.blank), .text("A")),
-            .a(.href("b.html"), .rel(.nofollow), .text("B"))
+            .a(.href("b.html"), .rel(.nofollow), .text("B")),
+            .a(.href(require(URL(string: "c.html"))), .text("C"))
         ))
 
         assertEqualHTMLContent(html, """
         <body>\
         <a href="a.html" target="_blank">A</a>\
         <a href="b.html" rel="nofollow">B</a>\
+        <a href="c.html">C</a>\
         </body>
         """)
     }


### PR DESCRIPTION
This change enables `URL` values to be directly passed to DSL APIs that accept a URL, such as `.src()`, `.href()`, and so on. Rather than having to implement overloads for each API, and rather than having to “pollute” standard types like `String` and `URL` with new properties/methods, this
implementation piggybacks on the `CustomStringConvertible` protocol - but still includes a “marker” protocol called `URLRepresentable` to prevent *any* string convertible type from being passed to these APIs.