### PR TITLE
Add support for textarea element

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -73,6 +73,8 @@ public extension HTML {
     enum ImageContext: HTMLSourceContext, HTMLStylableContext {}
     /// The context within an HTML `<input>` element.
     enum InputContext: HTMLNamableContext, HTMLValueContext {}
+    /// The context within an HTML `<textarea>` element.
+    final class TextAreaContext: HTMLNamableContext {}
     /// The context within an HTML `<label>` element.
     final class LabelContext: BodyContext {}
     /// The context within an HTML `<link>` element.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -224,6 +224,26 @@ public extension Attribute where Context == HTML.InputContext {
     }
 }
 
+public extension Node where Context == HTML.TextAreaContext {
+    /// Assign an input type to the element.
+    /// - parameter type: The input type to assign.
+    static func cols(_ cols: Int) -> Node {
+        .attribute(named: "cols", value: String(cols))
+    }
+
+    /// Assign whether the element should have autocomplete turned on or off.
+    /// - parameter isOn: Whether autocomplete should be turned on.
+    static func rows(_ rows: Int) -> Node {
+        .attribute(named: "rows", value: String(rows))
+    }
+
+    /// Assign whether the element should be autofocused when the page loads.
+    /// - parameter isOn: Whether autofocus should turned on.
+    static func autofocus(_ isOn: Bool) -> Node {
+        isOn ? .attribute(named: "autofocus", value: "true") : .empty
+    }
+}
+
 public extension Attribute where Context == HTML.OptionContext {
     /// Specify whether the option should be initially selected.
     /// - parameter isSelected: Whether the option should be selected.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -217,6 +217,12 @@ public extension Attribute where Context == HTML.InputContext {
         Attribute(name: "autocomplete", value: isOn ? "on" : "off")
     }
 
+    /// Assign whether the element is required before submitting the form.
+    /// - parameter isOn: Whether required should set to true.
+    static func required(_ isOn: Bool) -> Attribute {
+        isOn ? Attribute(name: "required", value: "true") : .empty
+    }
+    
     /// Assign whether the element should be autofocused when the page loads.
     /// - parameter isOn: Whether autofocus should turned on.
     static func autofocus(_ isOn: Bool) -> Attribute {
@@ -225,18 +231,24 @@ public extension Attribute where Context == HTML.InputContext {
 }
 
 public extension Node where Context == HTML.TextAreaContext {
-    /// Assign an input type to the element.
-    /// - parameter type: The input type to assign.
+    /// Assign the number of text columns to text area.
+    /// - parameter cols: The number of columns.
     static func cols(_ cols: Int) -> Node {
         .attribute(named: "cols", value: String(cols))
     }
 
-    /// Assign whether the element should have autocomplete turned on or off.
-    /// - parameter isOn: Whether autocomplete should be turned on.
+    /// Assign the number of text rows visible to text area.
+    /// - parameter rows: The number of rows..
     static func rows(_ rows: Int) -> Node {
         .attribute(named: "rows", value: String(rows))
     }
-
+    
+    /// Assign whether the element is required before submitting the form.
+    /// - parameter isOn: Whether required should set to true.
+    static func required(_ isOn: Bool) -> Node {
+        isOn ? .attribute(named: "required", value: "true") : .empty
+    }
+    
     /// Assign whether the element should be autofocused when the page loads.
     /// - parameter isOn: Whether autofocus should turned on.
     static func autofocus(_ isOn: Bool) -> Node {

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -420,11 +420,17 @@ public extension Node where Context == HTML.FormContext {
     static func fieldset(_ nodes: Node<HTML.FormContext>...) -> Node {
         .element(named: "fieldset", nodes: nodes)
     }
-
+    
     /// Add an `<input/>` HTML element within the current context.
     /// - parameter nodes: The element's attributes.
     static func input(_ attributes: Attribute<HTML.InputContext>...) -> Node {
         .selfClosedElement(named: "input", attributes: attributes)
+    }
+    
+    /// Add a `<textarea>` HTML element within the current context.
+    /// - parameter attributes: The element's attributes.
+    static func textarea(_ nodes: Node<HTML.TextAreaContext>...) -> Node {
+        .element(named: "textarea", nodes: nodes)
     }
 }
 

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -428,7 +428,7 @@ public extension Node where Context == HTML.FormContext {
     }
     
     /// Add a `<textarea>` HTML element within the current context.
-    /// - parameter attributes: The element's attributes.
+    /// - parameter nodes: The element's attributes and nodes.
     static func textarea(_ nodes: Node<HTML.TextAreaContext>...) -> Node {
         .element(named: "textarea", nodes: nodes)
     }

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -231,7 +231,8 @@ final class HTMLTests: XCTestCase {
                 ),
                 .input(.name("b"), .type(.search), .autocomplete(false), .autofocus(true)),
                 .input(.name("c"), .type(.text), .autofocus(false)),
-                .input(.name("d"), .type(.email), .autocomplete(true)),
+                .input(.name("d"), .type(.email), .autocomplete(true), .required(true)),
+                .textarea(.name("e"), .cols(50), .rows(10), .required(true), .text("Test")),
                 .input(.type(.submit), .value("Send"))
             )
         ))
@@ -244,7 +245,8 @@ final class HTMLTests: XCTestCase {
         </fieldset>\
         <input name="b" type="search" autocomplete="off" autofocus="true"/>\
         <input name="c" type="text"/>\
-        <input name="d" type="email" autocomplete="on"/>\
+        <input name="d" type="email" autocomplete="on" required="true"/>\
+        <textarea name="e" cols="50" rows="10" required="true">Test</textarea>\
         <input type="submit" value="Send"/>\
         </form></body>
         """)


### PR DESCRIPTION
Adds support for `<textarea>` HTML element. 

Create `TextAreaContext` which provides `rows`, `cols`, `required` and `autofocus` attributes. It takes a list of Nodes so you can add `.text` node.

Included `textarea` in testForm() test that already exists.

At the same time added a `required` attribute to `Attribute where Context == HTML.InputContext`.