### PR TITLE
Control flow: Support throwing closures

### DIFF
--- a/Sources/Plot/API/ControlFlow.swift
+++ b/Sources/Plot/API/ControlFlow.swift
@@ -26,8 +26,8 @@ public extension Node {
     /// be created.
     /// - parameter optional: The optional value to unwrap.
     /// - parameter transform: The closure to use to transform the value into a node.
-    static func unwrap<T>(_ optional: T?, _ transform: (T) -> Node) -> Node {
-        optional.map(transform) ?? .empty
+    static func unwrap<T>(_ optional: T?, _ transform: (T) throws -> Node) rethrows -> Node {
+        try optional.map(transform) ?? .empty
     }
 
     /// Transform any sequence of values into a group of nodes, by applying a
@@ -35,7 +35,7 @@ public extension Node {
     /// - parameter sequence: The sequence to transform.
     /// - parameter transform: The closure to use to transform each element into a node.
     static func forEach<S: Sequence>(_ sequence: S,
-                                     _ transform: (S.Element) -> Node) -> Node {
-        .group(sequence.map(transform))
+                                     _ transform: (S.Element) throws -> Node) rethrows -> Node {
+        try .group(sequence.map(transform))
     }
 }


### PR DESCRIPTION
Mark `unwrap` and `forEach` as `rethrows` to allow any closure passed into those APIs to throw.