### PR TITLE
Node: Prevent HTML entities from being double-escaped

### DIFF
--- a/Sources/Plot/Internal/String+Escaping.swift
+++ b/Sources/Plot/Internal/String+Escaping.swift
@@ -6,17 +6,44 @@
 
 internal extension String {
     func escaped() -> String {
-        String(flatMap { character -> String in
+        var pendingAmpersandString: String?
+
+        func flushPendingAmpersandString(
+            withSuffix suffix: String? = nil,
+            resettingTo newValue: String? = nil
+        ) -> String {
+            let pending = pendingAmpersandString
+            pendingAmpersandString = newValue
+            return pending.map { "&amp;\($0)\(suffix ?? "")" } ?? suffix ?? ""
+        }
+
+        return String(flatMap { character -> String in
             switch character {
             case "<":
-                return "&lt;"
+                return flushPendingAmpersandString(withSuffix: "&lt;")
             case ">":
-                return "&gt;"
+                return flushPendingAmpersandString(withSuffix: "&gt;")
             case "&":
-                return "&amp;"
+                return flushPendingAmpersandString(resettingTo: "")
+            case ";":
+                let pending = pendingAmpersandString.map { "&\($0);" }
+                pendingAmpersandString = nil
+                return pending ?? ";"
+            case "#" where pendingAmpersandString?.isEmpty == true:
+                pendingAmpersandString = "#"
+                return ""
             default:
+                if let pending = pendingAmpersandString {
+                    guard character.isLetter || character.isNumber else {
+                        return flushPendingAmpersandString(withSuffix: String(character))
+                    }
+
+                    pendingAmpersandString = "\(pending)\(character)"
+                    return ""
+                }
+
                 return "\(character)"
             }
-        })
+        }) + flushPendingAmpersandString()
     }
 }

--- a/Tests/PlotTests/NodeTests.swift
+++ b/Tests/PlotTests/NodeTests.swift
@@ -13,6 +13,21 @@ final class NodeTests: XCTestCase {
         XCTAssertEqual(node.render(), "Hello &amp; welcome to &lt;Plot&gt;!")
     }
 
+    func testEscapingDoubleAmpersands() {
+        let node = Node<Any>.text("&&")
+        XCTAssertEqual(node.render(), "&amp;&amp;")
+    }
+
+    func testEscapingAmpersandFollowedByComparisonSymbols() {
+        let node = Node<Any>.text("&< &>")
+        XCTAssertEqual(node.render(), "&amp;&lt; &amp;&gt;")
+    }
+
+    func testNotDoubleEscapingText() {
+        let node = Node<Any>.text("Hello &amp; welcome&#160;to &lt;Plot&gt;!&text")
+        XCTAssertEqual(node.render(), "Hello &amp; welcome&#160;to &lt;Plot&gt;!&amp;text")
+    }
+
     func testNotEscapingRawString() {
         let node = Node<Any>.raw("Hello & welcome to <Plot>!")
         XCTAssertEqual(node.render(), "Hello & welcome to <Plot>!")
@@ -62,6 +77,9 @@ extension NodeTests {
     static var allTests: Linux.TestList<NodeTests> {
         [
             ("testEscapingText", testEscapingText),
+            ("testEscapingDoubleAmpersands", testEscapingDoubleAmpersands),
+            ("testEscapingAmpersandFollowedByComparisonSymbols", testEscapingAmpersandFollowedByComparisonSymbols),
+            ("testNotDoubleEscapingText", testNotDoubleEscapingText),
             ("testNotEscapingRawString", testNotEscapingRawString),
             ("testGroup", testGroup),
             ("testCustomElement", testCustomElement),


### PR DESCRIPTION
This patch makes sure that any HTML entities contained within a string passed to `Node.text` won’t be double-escaped, by making the string escaping code read ahead when encountering an ampersand, and then filling in any pending text following it once it has determined that it wasn’t the start of an HTML entity. With this approach, the performance impact on the escaping code is very low, since it retains close to `O(N)` time complexity.