### PR TITLE
Podcast: Correctly pad duration numbers lower than 10

### DIFF
--- a/Sources/Plot/API/PodcastElements.swift
+++ b/Sources/Plot/API/PodcastElements.swift
@@ -133,7 +133,7 @@ public extension Node where Context == PodcastFeed.ItemContext {
     /// - parameter seconds: The number of seconds.
     static func duration(hours: Int, minutes: Int, seconds: Int) -> Node {
         func wrap(_ number: Int) -> String {
-            number == 0 ? "00" : String(number)
+            number < 10 ? "0\(number)" : String(number)
         }
 
         return .duration("\(wrap(hours)):\(wrap(minutes)):\(wrap(seconds))")

--- a/Tests/PlotTests/PodcastFeedTests.swift
+++ b/Tests/PlotTests/PodcastFeedTests.swift
@@ -167,13 +167,15 @@ final class PodcastFeedTests: XCTestCase {
     func testEpisodeDuration() {
         let feed = PodcastFeed(.item(
             .duration("00:15:12"),
-            .duration(hours: 00, minutes: 15, seconds: 12)
+            .duration(hours: 0, minutes: 15, seconds: 12),
+            .duration(hours: 1, minutes: 2, seconds: 3)
         ))
 
         assertEqualPodcastFeedContent(feed, """
         <item>\
         <itunes:duration>00:15:12</itunes:duration>\
         <itunes:duration>00:15:12</itunes:duration>\
+        <itunes:duration>01:02:03</itunes:duration>\
         </item>
         """)
     }


### PR DESCRIPTION
This patch fixes the podcast duration padding code, to make sure that a leading zero is always added for hour, minute or second values that are less than 10.