### PR TITLE
Minor documentation fixes + restore 100% test coverage

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -217,39 +217,39 @@ public extension Attribute where Context == HTML.InputContext {
     }
 
     /// Assign whether the element is required before submitting the form.
-    /// - parameter isOn: Whether required should set to true.
-    static func required(_ isOn: Bool) -> Attribute {
-        isOn ? Attribute(name: "required", value: "true") : .empty
+    /// - parameter isRequired: Whether the element is required.
+    static func required(_ isRequired: Bool) -> Attribute {
+        isRequired ? Attribute(name: "required", value: "true") : .empty
     }
     
     /// Assign whether the element should be autofocused when the page loads.
-    /// - parameter isOn: Whether autofocus should turned on.
+    /// - parameter isOn: Whether autofocus should be turned on.
     static func autofocus(_ isOn: Bool) -> Attribute {
         isOn ? Attribute(name: "autofocus", value: "true") : .empty
     }
 }
 
 public extension Node where Context == HTML.TextAreaContext {
-    /// Assign the number of text columns to text area.
-    /// - parameter cols: The number of columns.
-    static func cols(_ cols: Int) -> Node {
-        .attribute(named: "cols", value: String(cols))
+    /// Specify the number of columns that the text area should contain.
+    /// - parameter columns: The number of columns to specify.
+    static func cols(_ columns: Int) -> Node {
+        .attribute(named: "cols", value: String(columns))
     }
 
-    /// Assign the number of text rows visible to text area.
-    /// - parameter rows: The number of rows..
+    /// Specify the number of text rows that should be visible within the text area.
+    /// - parameter rows: The number of rows to specify.
     static func rows(_ rows: Int) -> Node {
         .attribute(named: "rows", value: String(rows))
     }
     
     /// Assign whether the element is required before submitting the form.
-    /// - parameter isOn: Whether required should set to true.
-    static func required(_ isOn: Bool) -> Node {
-        isOn ? .attribute(named: "required", value: "true") : .empty
+    /// - parameter isRequired: Whether the element is required.
+    static func required(_ isRequired: Bool) -> Node {
+        isRequired ? .attribute(named: "required", value: "true") : .empty
     }
     
     /// Assign whether the element should be autofocused when the page loads.
-    /// - parameter isOn: Whether autofocus should turned on.
+    /// - parameter isOn: Whether autofocus should be turned on.
     static func autofocus(_ isOn: Bool) -> Node {
         isOn ? .attribute(named: "autofocus", value: "true") : .empty
     }

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -420,7 +420,7 @@ public extension Node where Context == HTML.FormContext {
     static func fieldset(_ nodes: Node<HTML.FormContext>...) -> Node {
         .element(named: "fieldset", nodes: nodes)
     }
-    
+
     /// Add an `<input/>` HTML element within the current context.
     /// - parameter nodes: The element's attributes.
     static func input(_ attributes: Attribute<HTML.InputContext>...) -> Node {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -233,6 +233,7 @@ final class HTMLTests: XCTestCase {
                 .input(.name("c"), .type(.text), .autofocus(false)),
                 .input(.name("d"), .type(.email), .autocomplete(true), .required(true)),
                 .textarea(.name("e"), .cols(50), .rows(10), .required(true), .text("Test")),
+                .textarea(.name("f"), .autofocus(true)),
                 .input(.type(.submit), .value("Send"))
             )
         ))
@@ -247,6 +248,7 @@ final class HTMLTests: XCTestCase {
         <input name="c" type="text"/>\
         <input name="d" type="email" autocomplete="on" required="true"/>\
         <textarea name="e" cols="50" rows="10" required="true">Test</textarea>\
+        <textarea name="f" autofocus="true"></textarea>\
         <input type="submit" value="Send"/>\
         </form></body>
         """)

--- a/Tests/PlotTests/NodeTests.swift
+++ b/Tests/PlotTests/NodeTests.swift
@@ -9,8 +9,8 @@ import Plot
 
 final class NodeTests: XCTestCase {
     func testEscapingText() {
-        let node = Node<Any>.text("Hello & welcome to <Plot>!")
-        XCTAssertEqual(node.render(), "Hello &amp; welcome to &lt;Plot&gt;!")
+        let node = Node<Any>.text("Hello & welcome to <Plot>!;")
+        XCTAssertEqual(node.render(), "Hello &amp; welcome to &lt;Plot&gt;!;")
     }
 
     func testEscapingDoubleAmpersands() {


### PR DESCRIPTION
This change contains minor fixes to documentation wording, removal of unnecessary whitespace, and restore’s Plot’s 100% unit test coverage.