### PR TITLE
Implements textarea

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -73,6 +73,8 @@ public extension HTML {
     enum ImageContext: HTMLSourceContext, HTMLStylableContext {}
     /// The context within an HTML `<input>` element.
     enum InputContext: HTMLNamableContext, HTMLValueContext {}
+    /// The context within an HTML `<textarea>` element.
+    enum TextAreaContext: HTMLNamableContext, HTMLValueContext {}
     /// The context within an HTML `<label>` element.
     final class LabelContext: BodyContext {}
     /// The context within an HTML `<link>` element.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -224,6 +224,32 @@ public extension Attribute where Context == HTML.InputContext {
     }
 }
 
+public extension Attribute where Context == HTML.TextAreaContext {
+    /// Assign whether the element should have autocomplete turned on or off.
+    /// - parameter isOn: Whether autocomplete should be turned on.
+    static func autocomplete(_ isOn: Bool) -> Attribute {
+        Attribute(name: "autocomplete", value: isOn ? "on" : "off")
+    }
+
+    /// Assign whether the element should be autofocused when the page loads.
+    /// - parameter isOn: Whether autofocus should turned on.
+    static func autofocus(_ isOn: Bool) -> Attribute {
+        isOn ? Attribute(name: "autofocus", value: "true") : .empty
+    }
+    
+    static func rows(_ count: Int) -> Attribute {
+        Attribute(name: "rows", value: String(count))
+    }
+    
+    static func cols(_ count: Int) -> Attribute {
+        Attribute(name: "cols", value: String(count))
+    }
+    
+    static func maxlength(_ length: Int) -> Attribute {
+        Attribute(name: "maxlength", value: String(length))
+    }
+}
+
 public extension Attribute where Context == HTML.OptionContext {
     /// Specify whether the option should be initially selected.
     /// - parameter isSelected: Whether the option should be selected.

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -426,6 +426,12 @@ public extension Node where Context == HTML.FormContext {
     static func input(_ attributes: Attribute<HTML.InputContext>...) -> Node {
         .selfClosedElement(named: "input", attributes: attributes)
     }
+    
+    /// Add an `<textarea/>` HTML element within the current context.
+    /// - parameter nodes: The element's attributes.
+    static func textarea(_ attributes: Attribute<HTML.TextAreaContext>...) -> Node {
+        .element(named: "textarea", attributes: attributes)
+    }
 }
 
 // MARK: - Other

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -232,6 +232,7 @@ final class HTMLTests: XCTestCase {
                 .input(.name("b"), .type(.search), .autocomplete(false), .autofocus(true)),
                 .input(.name("c"), .type(.text), .autofocus(false)),
                 .input(.name("d"), .type(.email), .autocomplete(true)),
+                .textarea(.name("e"), .rows(40), .cols(20), .maxlength(200), .autocomplete(false)),
                 .input(.type(.submit), .value("Send"))
             )
         ))
@@ -245,6 +246,7 @@ final class HTMLTests: XCTestCase {
         <input name="b" type="search" autocomplete="off" autofocus="true"/>\
         <input name="c" type="text"/>\
         <input name="d" type="email" autocomplete="on"/>\
+        <textarea name="e" rows="40" cols="20" maxlength="200" autocomplete="off"></textarea>\
         <input type="submit" value="Send"/>\
         </form></body>
         """)


### PR DESCRIPTION
Implements `<textarea>`. Includes tests.

Example:
`.textarea(.name("e"), .rows(40), .cols(20), .maxlength(200), .autocomplete(false)),`

Note: There’s a lot of overlap between `textarea` and `input` which is causing a lot of copy-paste code. I would love some help on how to build this better.