### PR TITLE
Add <picture> and <source> elements

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -48,7 +48,7 @@ public extension HTML {
     /// The context within an HTML `<a>` element.
     final class AnchorContext: BodyContext, HTMLLinkableContext {}
     /// The context within an HTML `<audio>` element.
-    enum AudioContext: HTMLMediaContext {
+    enum AudioContext: HTMLMultiMediaContext {
         public typealias SourceContext = AudioSourceContext
     }
     /// The context within an audio `<source>` element.
@@ -70,7 +70,7 @@ public extension HTML {
     /// The context within an HTML `<iframe>` element.
     enum IFrameContext: HTMLNamableContext, HTMLSourceContext {}
     /// The context within an HTML `<img>` element.
-    enum ImageContext: HTMLSourceContext, HTMLStylableContext {}
+    enum ImageContext: HTMLSourceContext, HTMLStylableContext, HTMLSourceSetContext {}
     /// The context within an HTML `<input>` element.
     enum InputContext: HTMLNamableContext, HTMLValueContext {}
     /// The context within an HTML `<textarea>` element.
@@ -87,6 +87,8 @@ public extension HTML {
     enum OptionContext: HTMLValueContext {}
     /// The context within an HTML `<script>` element.
     enum ScriptContext: HTMLSourceContext {}
+    /// The context within an HTML `<source>` element
+    enum SourceSetContext: HTMLSourceContext, HTMLSourceSetContext, HTMLMediaContext {}
     /// The context within an HTML `<select>` element.
     enum SelectContext: HTMLOptionListContext {}
     /// The context within an HTML `<table>` element.
@@ -94,7 +96,7 @@ public extension HTML {
     /// The context within an HTML `<tr>` element.
     enum TableRowContext: HTMLStylableContext {}
     /// The context within an HTML `<video>` element.
-    enum VideoContext: HTMLMediaContext {
+    enum VideoContext: HTMLMultiMediaContext {
         public typealias SourceContext = VideoSourceContext
     }
     /// The context within a video `<source>` element.
@@ -109,9 +111,12 @@ public protocol HTMLDimensionContext: HTMLContext {}
 /// Context shared among all HTML elements that act as some form
 /// of link to an external resource, such as `<link>` or `<a>`.
 public protocol HTMLLinkableContext: HTMLContext {}
-/// Context shared among all HTML elements that enable media playback,
+/// Context shared among all HTML elements that support the `media`
+/// attribute for example `<source>`
+public protocol HTMLMediaContext: HTMLContext {}
+/// Context shared among all HTML elements that enable multimedia playback,
 /// such as `<audio>` and `<video>`.
-public protocol HTMLMediaContext: HTMLContext {
+public protocol HTMLMultiMediaContext: HTMLContext {
     /// The context within the media element's `<source>` element.
     associatedtype SourceContext: HTMLSourceContext
 }
@@ -127,6 +132,9 @@ public protocol HTMLScriptableContext: HTMLContext {}
 /// Context shared among all HTML elements that support the `src`
 /// attribute, for example `<img>` and `<iframe>`.
 public protocol HTMLSourceContext: HTMLContext {}
+/// Context shared among all HTML elements that support the `srcset`
+/// attribute, for example `<picture>`.
+public protocol HTMLSourceSetContext: HTMLContext {}
 /// Context shared among all HTML elements that can be styled using
 /// inline CSS through the `style` attribute.
 public protocol HTMLStylableContext: HTMLContext {}

--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -48,7 +48,7 @@ public extension HTML {
     /// The context within an HTML `<a>` element.
     final class AnchorContext: BodyContext, HTMLLinkableContext {}
     /// The context within an HTML `<audio>` element.
-    enum AudioContext: HTMLMultiMediaContext {
+    enum AudioContext: HTMLMultimediaContext {
         public typealias SourceContext = AudioSourceContext
     }
     /// The context within an audio `<source>` element.
@@ -85,10 +85,14 @@ public extension HTML {
     enum MetaContext: HTMLNamableContext {}
     /// The context within an HTML `<option>` element.
     enum OptionContext: HTMLValueContext {}
+    /// The context within an HTML `<picture>` element.
+    enum PictureContext: HTMLMultimediaContext {
+        public typealias SourceContext = PictureSourceContext
+    }
+    /// The context within a picture `<source>` element.
+    enum PictureSourceContext: HTMLSourceContext, HTMLSourceSetContext, HTMLMediaContext {}
     /// The context within an HTML `<script>` element.
     enum ScriptContext: HTMLSourceContext {}
-    /// The context within an HTML `<source>` element
-    enum SourceSetContext: HTMLSourceContext, HTMLSourceSetContext, HTMLMediaContext {}
     /// The context within an HTML `<select>` element.
     enum SelectContext: HTMLOptionListContext {}
     /// The context within an HTML `<table>` element.
@@ -96,7 +100,7 @@ public extension HTML {
     /// The context within an HTML `<tr>` element.
     enum TableRowContext: HTMLStylableContext {}
     /// The context within an HTML `<video>` element.
-    enum VideoContext: HTMLMultiMediaContext {
+    enum VideoContext: HTMLMultimediaContext {
         public typealias SourceContext = VideoSourceContext
     }
     /// The context within a video `<source>` element.
@@ -112,11 +116,11 @@ public protocol HTMLDimensionContext: HTMLContext {}
 /// of link to an external resource, such as `<link>` or `<a>`.
 public protocol HTMLLinkableContext: HTMLContext {}
 /// Context shared among all HTML elements that support the `media`
-/// attribute for example `<source>`
+/// attribute for example `<source>`.
 public protocol HTMLMediaContext: HTMLContext {}
 /// Context shared among all HTML elements that enable multimedia playback,
-/// such as `<audio>` and `<video>`.
-public protocol HTMLMultiMediaContext: HTMLContext {
+/// such as `<audio>`, `<video>` and `<picture>`.
+public protocol HTMLMultimediaContext: HTMLContext {
     /// The context within the media element's `<source>` element.
     associatedtype SourceContext: HTMLSourceContext
 }

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -161,7 +161,7 @@ public extension Node where Context: HTMLSourceContext {
     }
 }
 
-public extension Node where Context: HTMLMediaContext {
+public extension Node where Context: HTMLMultiMediaContext {
     /// Assign whether the element's media controls should be enabled.
     /// - parameter enableControls: Whether controls should be shown.
     static func controls(_ enableControls: Bool) -> Node {
@@ -182,6 +182,22 @@ public extension Attribute where Context == HTML.VideoSourceContext {
     /// - parameter format: The video format to assign.
     static func type(_ format: HTMLVideoFormat) -> Attribute {
         Attribute(name: "type", value: "video/" + format.rawValue)
+    }
+}
+
+public extension Attribute where Context: HTMLSourceSetContext {
+    /// Assign a source to the element, using its `srcset` attribute.
+    /// - parameter url: The source URL to assign.
+    static func srcset(_ url: URLRepresentable) -> Attribute {
+        Attribute(name: "srcset", value: url.string)
+    }
+}
+
+public extension Attribute where Context: HTMLMediaContext {
+    /// Assign a source to the element, using its `media` attribute.
+    /// - parameter url:Any valid media query that would normally be defined in a CSS
+    static func media(_ mediaQuery: String) -> Attribute {
+        Attribute(name: "media", value: mediaQuery)
     }
 }
 

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -161,7 +161,7 @@ public extension Node where Context: HTMLSourceContext {
     }
 }
 
-public extension Node where Context: HTMLMultiMediaContext {
+public extension Node where Context: HTMLMultimediaContext {
     /// Assign whether the element's media controls should be enabled.
     /// - parameter enableControls: Whether controls should be shown.
     static func controls(_ enableControls: Bool) -> Node {
@@ -187,17 +187,17 @@ public extension Attribute where Context == HTML.VideoSourceContext {
 
 public extension Attribute where Context: HTMLSourceSetContext {
     /// Assign a source to the element, using its `srcset` attribute.
-    /// - parameter url: The source URL to assign.
-    static func srcset(_ url: URLRepresentable) -> Attribute {
-        Attribute(name: "srcset", value: url.string)
+    /// - parameter versions: Comma separated list of images/pixel density pairs
+    static func srcset(_ versions: String) -> Attribute {
+        Attribute(name: "srcset", value: versions)
     }
 }
 
 public extension Attribute where Context: HTMLMediaContext {
     /// Assign a source to the element, using its `media` attribute.
-    /// - parameter url:Any valid media query that would normally be defined in a CSS
-    static func media(_ mediaQuery: String) -> Attribute {
-        Attribute(name: "media", value: mediaQuery)
+    /// - parameter query: Any valid media query that would normally be defined in CSS
+    static func media(_ query: String) -> Attribute {
+        Attribute(name: "media", value: query)
     }
 }
 

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -303,7 +303,7 @@ public extension Node where Context: HTML.BodyContext {
 
     /// Add a `<picture>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements
-    static func picture(_ nodes: Node<HTML.BodyContext>...) -> Node {
+    static func picture(_ nodes: Node<HTML.PictureContext>...) -> Node {
         .element(named: "picture", nodes: nodes)
     }
 
@@ -323,12 +323,6 @@ public extension Node where Context: HTML.BodyContext {
     /// - parameter nodes: The element's attributes and child elements.
     static func select(_ nodes: Node<HTML.SelectContext>...) -> Node {
         .element(named: "select", nodes: nodes)
-    }
-
-    /// Add a `<source>` HTML element within the current context.
-    /// - parameter nodes: The element's attributes and child elements.
-    static func source(_ attributes: Attribute<HTML.SourceSetContext>...) -> Node {
-        .selfClosedElement(named: "source", attributes: attributes)
     }
 
     /// Add a `<span>` HTML element within the current context.
@@ -454,11 +448,19 @@ public extension Node where Context == HTML.FormContext {
 
 // MARK: - Other
 
-public extension Node where Context: HTMLMultiMediaContext {
+public extension Node where Context: HTMLMultimediaContext {
     /// Add a `<source/>` HTML element within the current context.
     /// - parameter attributes: The element's attributes.
     static func source(_ attributes: Attribute<Context.SourceContext>...) -> Node {
         .selfClosedElement(named: "source", attributes: attributes)
+    }
+}
+
+public extension Node where Context == HTML.PictureContext {
+    /// Add an `<img/>` HTML element within the current context.
+    /// - parameter attributes: The element's attributes.
+    static func img(_ attributes: Attribute<HTML.ImageContext>...) -> Node {
+        .selfClosedElement(named: "img", attributes: attributes)
     }
 }
 

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -301,6 +301,12 @@ public extension Node where Context: HTML.BodyContext {
         .element(named: "pre", nodes: nodes)
     }
 
+    /// Add a `<picture>` HTML element within the current context.
+    /// - parameter nodes: The element's attributes and child elements
+    static func picture(_ nodes: Node<HTML.BodyContext>...) -> Node {
+        .element(named: "picture", nodes: nodes)
+    }
+
     /// Add an `<s>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements.
     static func s(_ nodes: Node<HTML.BodyContext>...) -> Node {
@@ -317,6 +323,12 @@ public extension Node where Context: HTML.BodyContext {
     /// - parameter nodes: The element's attributes and child elements.
     static func select(_ nodes: Node<HTML.SelectContext>...) -> Node {
         .element(named: "select", nodes: nodes)
+    }
+
+    /// Add a `<source>` HTML element within the current context.
+    /// - parameter nodes: The element's attributes and child elements.
+    static func source(_ attributes: Attribute<HTML.SourceSetContext>...) -> Node {
+        .selfClosedElement(named: "source", attributes: attributes)
     }
 
     /// Add a `<span>` HTML element within the current context.
@@ -442,7 +454,7 @@ public extension Node where Context == HTML.FormContext {
 
 // MARK: - Other
 
-public extension Node where Context: HTMLMediaContext {
+public extension Node where Context: HTMLMultiMediaContext {
     /// Add a `<source/>` HTML element within the current context.
     /// - parameter attributes: The element's attributes.
     static func source(_ attributes: Attribute<Context.SourceContext>...) -> Node {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -534,21 +534,21 @@ final class HTMLTests: XCTestCase {
         let html = HTML(.body(
             .picture(
                 .source(
-                    .src("/img"),
-                    .srcset("/img 2x"),
+                    .src("/img.jpg"),
+                    .srcset("/img-dark-2.jpg 2x, /img-dark-3.jpg 3x"),
                     .media("(prefers-color-scheme: dark)")
                 ),
                 .img(
-                    .src("/img"),
-                    .srcset("/img 2x")
+                    .src("/img.jpg"),
+                    .srcset("/img-light-2.jpg 2x, /img-light-3.jpg 3x")
                 )
             )
         ))
         assertEqualHTMLContent(html, """
         <body>\
         <picture>\
-        <source src="/img" srcset="/img 2x" media="(prefers-color-scheme: dark)"/>\
-        <img src="/img" srcset="/img 2x"/>\
+        <source src="/img.jpg" srcset="/img-dark-2.jpg 2x, /img-dark-3.jpg 3x" media="(prefers-color-scheme: dark)"/>\
+        <img src="/img.jpg" srcset="/img-light-2.jpg 2x, /img-light-3.jpg 3x"/>\
         </picture>\
         </body>
         """)

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -529,6 +529,30 @@ final class HTMLTests: XCTestCase {
         let html = HTML(.comment("Hello"), .body(.comment("World")))
         assertEqualHTMLContent(html, "<!--Hello--><body><!--World--></body>")
     }
+
+    func testPicture() {
+        let html = HTML(.body(
+            .picture(
+                .source(
+                    .src("/img"),
+                    .srcset("/img 2x"),
+                    .media("(prefers-color-scheme: dark)")
+                ),
+                .img(
+                    .src("/img"),
+                    .srcset("/img 2x")
+                )
+            )
+        ))
+        assertEqualHTMLContent(html, """
+        <body>\
+        <picture>\
+        <source src="/img" srcset="/img 2x" media="(prefers-color-scheme: dark)"/>\
+        <img src="/img" srcset="/img 2x"/>\
+        </picture>\
+        </body>
+        """)
+    }
 }
 
 extension HTMLTests {
@@ -584,7 +608,8 @@ extension HTMLTests {
             ("testAccessibilityControls", testAccessibilityControls),
             ("testAccessibilityExpanded", testAccessibilityExpanded),
             ("testDataAttributes", testDataAttributes),
-            ("testComments", testComments)
+            ("testComments", testComments),
+            ("testPicture", testPicture)
         ]
     }
 }


### PR DESCRIPTION
This adds support for the picture html element. This enables support for
differnet images in night mode and dark mode version of a website.

There was on issue where a class `HTMLMediaContext` protocol was
already being used for Video/Audio. I renamed that existing class to
`HTMLMultiMediaContext` to avoid a name collision. This also keeps the
`<meida>` attribute in line with the properties in the HTML WC3 picture
spec[1].

[Live Example](https://newsshield.app)
![demo](https://user-images.githubusercontent.com/1218847/72044808-9de1d780-3269-11ea-9fad-c92ed1c516b4.gif)


https://www.w3schools.com/html/html_images_picture.asp