### PR TITLE
Add Support for Subresource Integrity (SRI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ If you discover an element or attribute that’s missing, please [add it](CONTRI
 
 ## Credits, alternatives and focus
 
-Plot was originally written by [John Sundell](https://twitter.com/johnsundell) as part of the Publish suite of static site generation tools, which is used to build and generate [Swift by Sundell](https://swiftbysundell.com). That suite also includes the Markdown parser [Ink](https://github.com/JohnSundell/Ink), as well as Publish itself (which will be open sourced soon).
+Plot was originally written by [John Sundell](https://twitter.com/johnsundell) as part of the Publish suite of static site generation tools, which is used to build and generate [Swift by Sundell](https://swiftbysundell.com). That suite also includes the Markdown parser [Ink](https://github.com/JohnSundell/Ink), as well as [Publish](https://github.com/JohnSundell/Publish) itself.
 
 The idea of using Swift to generate HTML has also been explored by many other people and projects in the community, some of them similar to Plot, some of them completely different. For example [Leaf](https://github.com/vapor/leaf) by [Vapor](https://vapor.codes), [swift-html](https://github.com/pointfreeco/swift-html) by [Point-Free](https://www.pointfree.co), and the [Swift Talk backend](https://github.com/objcio/swift-talk-backend) by [objc.io](https://www.objc.io). The fact that there’s a lot of simultaneous innovation within this area is a great thing — since all of these tools (including Plot) have made different decisions around their overall API design and scope, which lets each developer pick the tool that best fits their individual taste and needs (or perhaps build yet another one?).
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ If you discover an element or attribute that’s missing, please [add it](CONTRI
 
 ## Credits, alternatives and focus
 
-Plot was originally written by [John Sundell](https://twitter.com/johnsundell) as part of the Publish suite of static site generation tools, which is used to build and generate [Swift by Sundell](https://swiftbysundell.com). That suite also includes the Markdown parser [Ink](https://github.com/JohnSundell/Ink), as well as [Publish](https://github.com/JohnSundell/Publish) itself.
+Plot was originally written by [John Sundell](https://twitter.com/johnsundell) as part of the Publish suite of static site generation tools, which is used to build and generate [Swift by Sundell](https://swiftbysundell.com). That suite also includes the Markdown parser [Ink](https://github.com/JohnSundell/Ink), as well as Publish itself (which will be open sourced soon).
 
 The idea of using Swift to generate HTML has also been explored by many other people and projects in the community, some of them similar to Plot, some of them completely different. For example [Leaf](https://github.com/vapor/leaf) by [Vapor](https://vapor.codes), [swift-html](https://github.com/pointfreeco/swift-html) by [Point-Free](https://www.pointfree.co), and the [Swift Talk backend](https://github.com/objcio/swift-talk-backend) by [objc.io](https://www.objc.io). The fact that there’s a lot of simultaneous innovation within this area is a great thing — since all of these tools (including Plot) have made different decisions around their overall API design and scope, which lets each developer pick the tool that best fits their individual taste and needs (or perhaps build yet another one?).
 

--- a/Sources/Plot/API/ControlFlow.swift
+++ b/Sources/Plot/API/ControlFlow.swift
@@ -39,3 +39,14 @@ public extension Node {
         try .group(sequence.map(transform))
     }
 }
+
+public extension Attribute {
+    /// Conditionally create a given attribute by unwrapping an optional, and then
+    /// applying a transform to it. If the optional is `nil`, then no attribute will
+    /// be created.
+    /// - parameter optional: The optional value to unwrap.
+    /// - parameter transform: The closure to use to transform the value into a node.
+    static func unwrap<T>(_ optional: T?, _ transform: (T) throws -> Attribute) rethrows -> Attribute {
+        try optional.map(transform) ?? .empty
+    }
+}

--- a/Sources/Plot/API/ControlFlow.swift
+++ b/Sources/Plot/API/ControlFlow.swift
@@ -45,8 +45,8 @@ public extension Attribute {
     /// applying a transform to it. If the optional is `nil`, then no attribute will
     /// be created.
     /// - parameter optional: The optional value to unwrap.
-    /// - parameter transform: The closure to use to transform the value into a node.
-    static func unwrap<T>(_ optional: T?, _ transform: (T) throws -> Attribute) rethrows -> Attribute {
+    /// - parameter transform: The closure to use to transform the value into an attribute.
+    static func unwrap<T>(_ optional: T?, _ transform: (T) throws -> Self) rethrows -> Self {
         try optional.map(transform) ?? .empty
     }
 }

--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -78,7 +78,7 @@ public extension HTML {
     /// The context within an HTML `<label>` element.
     final class LabelContext: BodyContext {}
     /// The context within an HTML `<link>` element.
-    enum LinkContext: HTMLLinkableContext, HTMLTypeContext {}
+    enum LinkContext: HTMLLinkableContext, HTMLTypeContext, HTMLIntegrityContext {}
     /// The context within an HTML list, such as `<ul>` or `<ol>` elements.
     enum ListContext: HTMLStylableContext {}
     /// The context within an HTML `<meta>` element.
@@ -86,7 +86,7 @@ public extension HTML {
     /// The context within an HTML `<option>` element.
     enum OptionContext: HTMLValueContext {}
     /// The context within an HTML `<script>` element.
-    enum ScriptContext: HTMLSourceContext {}
+    enum ScriptContext: HTMLSourceContext, HTMLIntegrityContext {}
     /// The context within an HTML `<select>` element.
     enum SelectContext: HTMLOptionListContext {}
     /// The context within an HTML `<table>` element.
@@ -115,6 +115,9 @@ public protocol HTMLMediaContext: HTMLContext {
     /// The context within the media element's `<source>` element.
     associatedtype SourceContext: HTMLSourceContext
 }
+/// Context shared among all HTML elements that support the `integrity`
+/// attribute, such as `<link>` and `<script>`
+public protocol HTMLIntegrityContext: HTMLContext {}
 /// Context shared among all HTML elements that support the `name`
 /// attribute, such as `<meta>` and `<input>`.
 public protocol HTMLNamableContext: HTMLContext {}

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -367,6 +367,24 @@ public extension Node where Context: HTML.BodyContext {
     }
 }
 
+// MARK: - Subresource Integrity
+
+public extension Attribute where Context: HTMLIntegrityContext {
+    /// Assign a source to the element, using its `integrity` attribute.
+    /// - parameter hash: base64-encoded cryptographic hash
+    static func integrity(_ hash: String) -> Attribute {
+        Attribute(name: "integrity", value: hash)
+    }
+}
+
+public extension Node where Context: HTMLIntegrityContext {
+    /// Assign a source to the element, using its `src` attribute.
+    /// - parameter hash: base64-encoded cryptographic hash
+    static func integrity(_ hash: String) -> Node {
+        .attribute(named: "integrity", value: hash)
+    }
+}
+
 // MARK: - Other, element-specific attributes
 
 public extension Node where Context == HTML.AbbreviationContext {
@@ -376,3 +394,5 @@ public extension Node where Context == HTML.AbbreviationContext {
         .attribute(named: "title", value: title)
     }
 }
+
+

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -370,7 +370,7 @@ public extension Node where Context: HTML.BodyContext {
 // MARK: - Subresource Integrity
 
 public extension Attribute where Context: HTMLIntegrityContext {
-    /// Assign a source to the element, using its `integrity` attribute.
+    /// Assign a subresouce integrity hash to the element, using its `integrity` attribute.
     /// - parameter hash: base64-encoded cryptographic hash
     static func integrity(_ hash: String) -> Attribute {
         Attribute(name: "integrity", value: hash)
@@ -378,7 +378,7 @@ public extension Attribute where Context: HTMLIntegrityContext {
 }
 
 public extension Node where Context: HTMLIntegrityContext {
-    /// Assign a source to the element, using its `src` attribute.
+    /// Assign a subresouce integrity hash to the element, using its `integrity` attribute.
     /// - parameter hash: base64-encoded cryptographic hash
     static func integrity(_ hash: String) -> Node {
         .attribute(named: "integrity", value: hash)
@@ -394,5 +394,3 @@ public extension Node where Context == HTML.AbbreviationContext {
         .attribute(named: "title", value: title)
     }
 }
-
-

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -13,8 +13,16 @@ public extension Node where Context == HTML.HeadContext {
 
     /// Link the HTML page to an external CSS stylesheet.
     /// - parameter url: The URL of the stylesheet to link to.
-    static func stylesheet(_ url: URLRepresentable) -> Node {
-        .link(.rel(.stylesheet), .href(url.string), .type("text/css"))
+    /// - parameter integrity: optional base64-encoded cryptographic hash
+    static func stylesheet(_ url: URLRepresentable, integrity: String? = nil) -> Node {
+        .link(
+            .rel(.stylesheet),
+            .href(url.string),
+            .type("text/css"),
+            .unwrap(integrity) {
+                .integrity($0)
+            }
+        )
     }
 
     /// Declare the HTML page's canonical URL, for social sharing and SEO.

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -19,9 +19,7 @@ public extension Node where Context == HTML.HeadContext {
             .rel(.stylesheet),
             .href(url.string),
             .type("text/css"),
-            .unwrap(integrity) {
-                .integrity($0)
-            }
+            .unwrap(integrity, Attribute.integrity)
         )
     }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -524,6 +524,21 @@ final class HTMLTests: XCTestCase {
         <body data-user-name="John"><img data-icon="User"/></body>
         """)
     }
+    
+    func testSubresourceIntegrity() {
+        let html = HTML(.head(
+            .script(.src("file.js"), .integrity("sha384-fakeHash")),
+            .link(.rel(.stylesheet), .href("styles.css"), .type("text/css"), .integrity("sha512-fakeHash")),
+            .stylesheet("styles2.css", integrity: "sha256-fakeHash")
+        ))
+
+        assertEqualHTMLContent(html, """
+        <head><script src="file.js" integrity="sha384-fakeHash"></script>\
+        <link rel="stylesheet" href="styles.css" type="text/css" integrity="sha512-fakeHash"/>\
+        <link rel="stylesheet" href="styles2.css" type="text/css" integrity="sha256-fakeHash"/>\
+        </head>
+        """)
+    }
 
     func testComments() {
         let html = HTML(.comment("Hello"), .body(.comment("World")))
@@ -584,6 +599,7 @@ extension HTMLTests {
             ("testAccessibilityControls", testAccessibilityControls),
             ("testAccessibilityExpanded", testAccessibilityExpanded),
             ("testDataAttributes", testDataAttributes),
+            ("testSubresourceIntegrity", testSubresourceIntegrity),
             ("testComments", testComments)
         ]
     }


### PR DESCRIPTION
This PR adds the `.integrity(_:String)` attribute to `<link>` and `<script>` elements and also adds an overload to the `.stylesheet` component to accept it as a second, named argument.

Also in doing this I added `.unwrap` to `Attribute` (whereas it was initially only on `Node`). I didn't go ahead and add `.if` and `.forEach` but they may be nice to have.

I also added a test for the three use cases.

---

[Mozilla](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity):

>Subresource Integrity (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a CDN) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.