### PR TITLE
HTML links: Post-merge fixes

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -110,6 +110,24 @@ public extension Attribute where Context == HTML.LinkContext {
     static func rel(_ relationship: HTMLLinkRelationship) -> Attribute {
         Attribute(name: "rel", value: relationship.rawValue)
     }
+
+    /// Assign an `hreflang` attribute to this element.
+    /// - parameter language: The language to assign.
+    static func hreflang(_ language: Language) -> Attribute {
+        Attribute(name: "hreflang", value: language.rawValue)
+    }
+
+    /// Assign an icon sizes string to this element.
+    /// - parameter sizes: The icon sizes string to assign.
+    static func sizes(_ sizes: String) -> Attribute {
+        Attribute(name: "sizes", value: sizes)
+    }
+
+    /// Assign an icon color string to this element.
+    /// - parameter color: The icon color string to assign.
+    static func color(_ color: String) -> Attribute {
+        Attribute(name: "color", value: color)
+    }
 }
 
 public extension Attribute where Context: HTMLLinkableContext {
@@ -125,27 +143,6 @@ public extension Node where Context: HTMLLinkableContext {
     /// - parameter url: The URL to assign.
     static func href(_ url: URLRepresentable) -> Node {
         .attribute(named: "href", value: url.string)
-    }
-}
-
-public extension Attribute where Context == HTML.LinkContext {
-    /// Assign a hreflang string to this element.
-    /// - parameter language: The language to assign.
-    /// - parameter country: The country of the language to assign.
-    static func hreflang(_ language: Language) -> Attribute {
-        Attribute(name: "hreflang", value: language.rawValue)
-    }
-
-    /// Assign an icon sizes string to this element.
-    /// - parameter sizes: The icon sizes of the link to assign.
-    static func sizes(_ sizes: String) -> Attribute {
-        Attribute(name: "sizes", value: sizes)
-    }
-
-    /// Assign an icon color string to this element.
-    /// - parameter color: The icon color of the link to assign.
-    static func color(_ color: String) -> Attribute {
-        Attribute(name: "color", value: color)
     }
 }
 

--- a/Sources/Plot/API/Language.swift
+++ b/Sources/Plot/API/Language.swift
@@ -192,7 +192,7 @@ public enum Language: String {
     case welsh = "cy"
     case wolof = "wo"
     case westernFrisian = "fy"
-    case xdefault = "x-default"
+    case xDefault = "x-default"
     case xhosa = "xh"
     case yiddish = "yi, ji"
     case yoruba = "yo"

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -128,50 +128,48 @@ final class HTMLTests: XCTestCase {
         """)
     }
 
-    func testLinkHrefLangEnglish() {
-        let html = HTML(.head(.link(.rel(.alternate), .href("http://site/"), .hreflang(.english))))
+    func testLinkWithHrefLang() {
+        let html = HTML(.head(.link(
+            .rel(.alternate),
+            .href("http://site/"),
+            .hreflang(.english)
+        )))
+
         assertEqualHTMLContent(html, """
         <head><link rel="alternate" href="http://site/" hreflang="en"/></head>
         """)
     }
 
-    func testLinkHrefLangEnglishUS() {
-        let html = HTML(.head(.link(.rel(.alternate), .href("http://site/"), .hreflang(.usEnglish))))
-        assertEqualHTMLContent(html, """
-        <head><link rel="alternate" href="http://site/" hreflang="en-us"/></head>
-        """)
-    }
+    func testAppleTouchIconLink() {
+        let html = HTML(.head(.link(
+            .rel(.appleTouchIcon),
+            .sizes("180x180"),
+            .href("apple-touch-icon.png")
+        )))
 
-    func testLinkHrefLangXdefault() {
-        let html = HTML(.head(.link(.rel(.alternate), .href("http://site/"), .hreflang(.xdefault))))
-        assertEqualHTMLContent(html, """
-        <head><link rel="alternate" href="http://site/" hreflang="x-default"/></head>
-        """)
-    }
-
-    func testLinkSizes() {
-        let html = HTML(.head(.link(.rel(.icon), .type("image/png"), .sizes("180x180"), .href("icon.png"))))
-        assertEqualHTMLContent(html, """
-        <head><link rel="icon" type="image/png" sizes="180x180" href="icon.png"/></head>
-        """)
-    }
-
-    func testLinkAppleTouchIcon() {
-        let html = HTML(.head(.link(.rel(.appleTouchIcon), .sizes("180x180"), .href("apple-touch-icon.png"))))
         assertEqualHTMLContent(html, """
         <head><link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png"/></head>
         """)
     }
 
-    func testLinkManifest() {
-        let html = HTML(.head(.link(.rel(.manifest), .href("site.webmanifest"))))
+    func testManifestLink() {
+        let html = HTML(.head(.link(
+            .rel(.manifest),
+            .href("site.webmanifest")
+        )))
+
         assertEqualHTMLContent(html, """
         <head><link rel="manifest" href="site.webmanifest"/></head>
         """)
     }
 
-    func testLinkMaskIcon() {
-        let html = HTML(.head(.link(.rel(.maskIcon), .href("safari-pinned-tab.svg"), .color("#000000"))))
+    func testMaskIconLink() {
+        let html = HTML(.head(.link(
+            .rel(.maskIcon),
+            .href("safari-pinned-tab.svg"),
+            .color("#000000")
+        )))
+
         assertEqualHTMLContent(html, """
         <head><link rel="mask-icon" href="safari-pinned-tab.svg" color="#000000"/></head>
         """)
@@ -648,13 +646,10 @@ extension HTMLTests {
             ("testStaticViewport", testStaticViewport),
             ("testFavicon", testFavicon),
             ("testRSSFeedLink", testRSSFeedLink),
-            ("testLinkHrefLangEnglish", testLinkHrefLangEnglish),
-            ("testLinkHrefLangEnglishUS", testLinkHrefLangEnglish),
-            ("testLinkHrefLangXdefault", testLinkHrefLangXdefault),
-            ("testLinkSizes", testLinkSizes),
-            ("testLinkAppleTouchIcon", testLinkAppleTouchIcon),
-            ("testLinkManifest", testLinkManifest),
-            ("testLinkMaskIcon", testLinkMaskIcon),
+            ("testLinkWithHrefLang", testLinkWithHrefLang),
+            ("testAppleTouchIconLink", testAppleTouchIconLink),
+            ("testManifestLink", testManifestLink),
+            ("testMaskIconLink", testMaskIconLink),
             ("testBodyWithID", testBodyWithID),
             ("testBodyWithCSSClass", testBodyWithCSSClass),
             ("testOverridingBodyCSSClass", testOverridingBodyCSSClass),


### PR DESCRIPTION
- Merge recent link attribute APIs with existing extension.
- Documentation fixes and improvements.
- CamelCase `x-default` language as `xDefault`.
- Merge tests that were testing the same code paths.
- Improve test naming and readability.