### PR TITLE
[Proposal] .rawFile element

### DIFF
--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -23,6 +23,8 @@ public enum Node<Context> {
     case text(String)
     /// A piece of raw text that will be rendered as-is.
     case raw(String)
+    /// An external file that will have its contents rendered.
+    case rawFile(String, String.Encoding)
     /// A group of nodes that should be rendered in sequence.
     case group([Node])
     /// An empty node, which won't be rendered.
@@ -135,6 +137,14 @@ extension Node: Renderable {
             return text.escaped()
         case .raw(let text):
             return text
+        case .rawFile(let path, let encoding):
+            let fileURL = URL(fileURLWithPath: path)
+            do {
+                let content = try String(contentsOf: fileURL, encoding: encoding)
+                return content
+            } catch {
+                return ""
+            }
         case .group(let nodes):
             return nodes.render(indentedBy: indentationKind)
         case .empty:

--- a/Sources/Plot/Internal/AnyNode.swift
+++ b/Sources/Plot/Internal/AnyNode.swift
@@ -19,6 +19,8 @@ extension Node: AnyNode {
             renderer.addText(text)
         case .raw(let text):
             renderer.addRawText(text)
+        case .rawFile(let text, let encoding):
+            renderer.addRawFile(text, encoding: encoding)
         case .group(let nodes):
             nodes.forEach { $0.render(into: renderer) }
         case .empty:

--- a/Sources/Plot/Internal/ElementRenderer.swift
+++ b/Sources/Plot/Internal/ElementRenderer.swift
@@ -51,6 +51,13 @@ internal final class ElementRenderer {
     func addRawText(_ text: String) {
         body.append(text)
     }
+    
+    func addRawFile(_ path: String, encoding: String.Encoding) {
+        let fileURL = URL(fileURLWithPath: path)
+        do {
+            body.append(try String(contentsOf: fileURL, encoding: encoding))
+        } catch {}
+    }
 
     func render<C>(withClosingMode closingMode: Element<C>.ClosingMode) -> String {
         guard !elementName.isEmpty else { return body }

--- a/Tests/PlotTests/NodeTests.swift
+++ b/Tests/PlotTests/NodeTests.swift
@@ -32,6 +32,11 @@ final class NodeTests: XCTestCase {
         let node = Node<Any>.raw("Hello & welcome to <Plot>!")
         XCTAssertEqual(node.render(), "Hello & welcome to <Plot>!")
     }
+    
+    func testRawFile() {
+        let node = Node<Any>.rawFile("TestResources/test.html", .utf8)
+        XCTAssertEqual(node.render(), #"<div class="foo" />"#)
+    }
 
     func testGroup() {
         let node = Node<Any>.group(.text("Hello"), .text("World"))

--- a/Tests/PlotTests/TestResources/test.html
+++ b/Tests/PlotTests/TestResources/test.html
@@ -1,0 +1,1 @@
+<div class="foo" />


### PR DESCRIPTION
**Status: Not Working** ❌

I didn't quite have time to get this in working order tonight but wanted to see if it's something you'd even like to include before I go any further.

Plot already provides a `.raw` node type if a developer wants to insert arbitrary text into their generated markup. I am proposing a similar helper called `.rawFile` which will read a file and then insert its contents into the generated markup.

**Example use case:** I have many svg files generated by a design program, which I would like to insert into my pages generated by Plot. Currently I have three options:

1. Painstakingly convert svgs to typed Plot DSL (unrealistic) or write a program to do so (very cool idea, but not for me right now 😂)
2. Copy svg into swift code as strings and use `.raw` element.
3. Read files in each individual place I want to use an svg, store in a string and use a `.raw` element.

This proposal would be a shortcut for option 3.