### PR TITLE
Add ability to create Nodes with text variables / constants

### DIFF
--- a/Tests/PlotTests/NodeTests.swift
+++ b/Tests/PlotTests/NodeTests.swift
@@ -71,6 +71,19 @@ final class NodeTests: XCTestCase {
 
         XCTAssertEqual(node.render(), #"<custom key="value"/>"#)
     }
+    
+    func testNodeCanBeCreatedUsingStringValue() {
+        let node = Node<Any>("Hello World")
+        
+        XCTAssertEqual(node.render(), "Hello World")
+    }
+    
+    func testNodeCanBeCreatedUsingStringVariable() {
+        let text = "Hello World"
+        let node = Node<Any>(text)
+        
+        XCTAssertEqual(node.render(), "Hello World")
+    }
 }
 
 extension NodeTests {
@@ -86,7 +99,9 @@ extension NodeTests {
             ("testCustomAttribute", testCustomAttribute),
             ("testCustomElementWithCustomAttribute", testCustomElementWithCustomAttribute),
             ("testCustomElementWithCustomAttributeWithSpecificContext", testCustomElementWithCustomAttributeWithSpecificContext),
-            ("testCustomSelfClosedElementWithCustomAttribute", testCustomSelfClosedElementWithCustomAttribute)
+            ("testCustomSelfClosedElementWithCustomAttribute", testCustomSelfClosedElementWithCustomAttribute),
+            ("testNodeCanBeCreatedUsingStringValue", testNodeCanBeCreatedUsingStringValue),
+            ("testNodeCanBeCreatedUsingStringVariable", testNodeCanBeCreatedUsingStringVariable)
         ]
     }
 }


### PR DESCRIPTION
As I was playing around with the package earlier, I noticed something that seems like a strange design decision:

Nodes can be created using string literals, but not string variables. Eg.

```swift
Node("Hello World")
```
works, but
```swift
let text = "Hello World"
Node(text)
```
is not possible. Instead you must use
```swift
Node(stringLiteral: text)
```

Due to the design of the Plot DSL, this leads to the fact that one cannot do:
```swift
let text = "Hello World"
let html = HTML(
    .body(
        .h1(text)
    )
)
```

But rather you must implement it as:
```swift
let text = "Hello World"
let html = HTML(
    .body(
        .h1(Node(stringLiteral: text))
    )
)
```

Unless I am missing something, that just doesn't feel very "pretty". I think it should be possible to pass a string variable, just as it's possible to pass a string literal.

I've attached an implementation of what I want, in the form of two unit tests to clarify. But frankly I don't quite understand the internals of the Node object, enough to try to implement this change myself.
Nor do I want to spend my time doing it, if you don't think it's the right move.

Thanks!