### PR TITLE
Adds support for appending values to attributes

### DIFF
--- a/Sources/Plot/API/Attribute.swift
+++ b/Sources/Plot/API/Attribute.swift
@@ -15,6 +15,8 @@ public struct Attribute<Context> {
     public var name: String
     /// The attribute's value
     public var value: String?
+    /// Whether the attribute should be appended to an existing attribute if found
+    public var shouldAppend: Bool
     /// Whether the attribute should be completely ignored if it has no value
     public var ignoreIfValueIsEmpty: Bool
 
@@ -22,18 +24,12 @@ public struct Attribute<Context> {
     /// opt out of ignoring the attribute if its value is empty.
     public init(name: String,
                 value: String?,
+                shouldAppend: Bool = false,
                 ignoreIfValueIsEmpty: Bool = true) {
         self.name = name
         self.value = value
+        self.shouldAppend = shouldAppend
         self.ignoreIfValueIsEmpty = ignoreIfValueIsEmpty
-    }
-    
-    /// Appends text to the attribute's value, separated by a space by default.
-    /// - parameter additionalValue: The value to append to the existing value.
-    /// - parameter separator: The separator used between the new and existing value,
-    /// defaults to a space if not specified.
-    public mutating func append(_ additionalValue: String, separator: String = " ") {
-        value?.append(separator + additionalValue)
     }
 }
 
@@ -59,8 +55,18 @@ internal extension Attribute where Context == Any {
     }
 }
 
+internal extension Attribute {
+    /// Appends text to the attribute's value, separated by a space by default.
+    /// - parameter additionalValue: The value to append to the existing value.
+    /// - parameter separator: The separator to use between the new and existing values.
+    mutating func append(_ additionalValue: String, separator: String) {
+        value?.append(separator + additionalValue)
+    }
+}
+
 internal protocol AnyAttribute {
     var name: String { get }
+    var value: String? { get }
     func render() -> String
 }
 

--- a/Sources/Plot/API/Attribute.swift
+++ b/Sources/Plot/API/Attribute.swift
@@ -27,6 +27,14 @@ public struct Attribute<Context> {
         self.value = value
         self.ignoreIfValueIsEmpty = ignoreIfValueIsEmpty
     }
+    
+    /// Appends text to the attribute's value, separated by a space by default.
+    /// - parameter additionalValue: The value to append to the existing value.
+    /// - parameter separator: The separator used between the new and existing value,
+    /// defaults to a space if not specified.
+    public mutating func append(_ additionalValue: String, separator: String = " ") {
+        value?.append(separator + additionalValue)
+    }
 }
 
 public extension Attribute {

--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -121,6 +121,26 @@ public extension Node {
     static func group(_ members: Node...) -> Node {
         .group(members)
     }
+    
+    /// Appends text to the attribute's value, separated by a space by default.
+    /// - parameter additionalValue: The value to append to the existing value.
+    /// - parameter separator: The separator used between the new and existing value,
+    /// defaults to a space if not specified.
+    func append(_ additionalValue: String, separator: String = " ") -> Node {
+        switch self {
+        case var .attribute(attribute):
+            attribute.append(additionalValue, separator: separator)
+            return .attribute(attribute)
+        case var .text(text):
+            text.append(separator + additionalValue)
+            return .text(text)
+        case var .raw(text):
+            text.append(separator + additionalValue)
+            return .raw(text)
+        default:
+            return self
+        }
+    }
 }
 
 extension Node: Renderable {

--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -18,7 +18,7 @@ public enum Node<Context> {
     /// An element, which can potentially have children.
     case element(Element<Context>)
     /// An attribute attached to an element.
-    case attribute(Attribute<Context>)
+    case attribute(Attribute<Context>, separator: String? = nil)
     /// A piece of free-form text that should be escaped.
     case text(String)
     /// A piece of raw text that will be rendered as-is.
@@ -115,32 +115,21 @@ public extension Node {
             ignoreIfValueIsEmpty: ignoreIfValueIsEmpty
         ))
     }
+    
+    /// Appends a value to a previously added attribute.
+    /// - parameter attribute: The attribute to append.
+    /// - parameter separator: The separator to use between the new and existing values,
+    ///   defaults to a space if not specified.
+    static func append(_ attribute: Attribute<Context>, separator: String = " ") -> Node {
+        var attribute = attribute
+        attribute.shouldAppend = true
+        return .attribute(attribute, separator: separator)
+    }
 
     /// Create a group of nodes using variadic parameter syntax.
     /// - parameter members: The nodes that should be included in the group.
     static func group(_ members: Node...) -> Node {
         .group(members)
-    }
-    
-    /// Appends text to the value, separated by a space by default. Only available on Nodes
-    /// of type `.attribute`, `.text`, and `.raw`.
-    /// - parameter additionalValue: The value to append to the existing value.
-    /// - parameter separator: The separator used between the new and existing value,
-    /// defaults to a space if not specified.
-    func append(_ additionalValue: String, separator: String = " ") -> Node {
-        switch self {
-        case var .attribute(attribute):
-            attribute.append(additionalValue, separator: separator)
-            return .attribute(attribute)
-        case var .text(text):
-            text.append(separator + additionalValue)
-            return .text(text)
-        case var .raw(text):
-            text.append(separator + additionalValue)
-            return .raw(text)
-        default:
-            return self
-        }
     }
 }
 
@@ -150,7 +139,7 @@ extension Node: Renderable {
         case .element(let element):
             let indentation = indentationKind.map(Indentation.init)
             return element.render(indentedBy: indentation)
-        case .attribute(let attribute):
+        case .attribute(let attribute, _):
             return attribute.render()
         case .text(let text):
             return text.escaped()

--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -122,7 +122,8 @@ public extension Node {
         .group(members)
     }
     
-    /// Appends text to the attribute's value, separated by a space by default.
+    /// Appends text to the value, separated by a space by default. Only available on Nodes
+    /// of type `.attribute`, `.text`, and `.raw`.
     /// - parameter additionalValue: The value to append to the existing value.
     /// - parameter separator: The separator used between the new and existing value,
     /// defaults to a space if not specified.

--- a/Sources/Plot/Internal/AnyNode.swift
+++ b/Sources/Plot/Internal/AnyNode.swift
@@ -13,8 +13,8 @@ extension Node: AnyNode {
         switch self {
         case .element(let element):
             renderer.addElement(element)
-        case .attribute(let attribute):
-            renderer.addAttribute(attribute)
+        case .attribute(let attribute, let separator):
+            renderer.addAttribute(attribute, separator: separator ?? " ")
         case .text(let text):
             renderer.addText(text)
         case .raw(let text):

--- a/Sources/Plot/Internal/ElementRenderer.swift
+++ b/Sources/Plot/Internal/ElementRenderer.swift
@@ -32,16 +32,27 @@ internal final class ElementRenderer {
         containsChildElements = true
     }
 
-    func addAttribute<C>(_ attribute: Attribute<C>) {
+    func addAttribute<C>(_ attribute: Attribute<C>, separator: String) {
         guard !attribute.name.isEmpty else { return }
 
         if let index = attributeIndexes[attribute.name] {
-            attributes[index] = attribute
+            if attribute.shouldAppend, let value = attribute.value {
+                appendValueToAttribute(at: index, value: value, context: C.self, separator: separator)
+            } else {
+                attributes[index] = attribute
+            }
             return
         }
 
         attributes.append(attribute)
         attributeIndexes[attribute.name] = attributes.count - 1
+    }
+    
+    private func appendValueToAttribute<C>(at index: Int, value: String, context: C, separator: String) {
+        let existingAttribute = attributes[index]
+        var newAttribute = Attribute<C>(name: existingAttribute.name, value: existingAttribute.value)
+        newAttribute.append(value, separator: separator)
+        attributes[index] = newAttribute
     }
 
     func addText(_ text: String) {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -189,6 +189,11 @@ final class HTMLTests: XCTestCase {
         let html = HTML(.body(.class("a"), .class("b")))
         assertEqualHTMLContent(html, #"<body class="b"></body>"#)
     }
+    
+    func testAppendingBodyCSSClass() {
+        let html = HTML(.body(Node.class("a").append("b")))
+        assertEqualHTMLContent(html, #"<body class="a b"></body>"#)
+    }
 
     func testUnorderedList() {
         let html = HTML(.body(.ul(.li("Text"))))
@@ -676,6 +681,7 @@ extension HTMLTests {
             ("testBodyWithID", testBodyWithID),
             ("testBodyWithCSSClass", testBodyWithCSSClass),
             ("testOverridingBodyCSSClass", testOverridingBodyCSSClass),
+            ("testAppendingBodyCSSClass", testAppendingBodyCSSClass),
             ("testUnorderedList", testUnorderedList),
             ("testOrderedList", testOrderedList),
             ("testDescriptionList", testDescriptionList),

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -191,7 +191,7 @@ final class HTMLTests: XCTestCase {
     }
     
     func testAppendingBodyCSSClass() {
-        let html = HTML(.body(Node.class("a").append("b")))
+        let html = HTML(.body(.class("a"), .append(.class("b"))))
         assertEqualHTMLContent(html, #"<body class="a b"></body>"#)
     }
 


### PR DESCRIPTION
This PR adds support for `append(additionalValue:separator:)` on attributes to allow adding additional values to an attribute. An example use case for this would be adding additional classes.

Also adds a new test, `testAppendingBodyCSSClass()` that checks that the value is appended correctly.

**Example Code:**
```swift
.body(Node.class("a").append("b"))
// Output: <body class="a b"></body>
```

Note: I'm not sure if there's a better way but due to the addition of `.append("b")` it requires adding `Node.` to the start of the attribute otherwise Xcode throws an error.