### PR TITLE
Add novalidate form attribute

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -238,6 +238,13 @@ public extension Node where Context == HTML.FormContext {
     static func method(_ method: HTMLFormMethod) -> Node {
         .attribute(named: "method", value: method.rawValue)
     }
+    
+    /// Adds the `novalidate` attribute to the form, which
+    /// prevents native browser validation on the form.
+    /// - Parameter method: The HTTP request method to use.
+    static func novalidate(_ isOn: Bool) -> Attribute {
+        isOn ? .attribute(named: "novalidate") : .empty
+    }
 }
 
 public extension Node where Context == HTML.LabelContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -239,9 +239,9 @@ public extension Node where Context == HTML.FormContext {
         .attribute(named: "method", value: method.rawValue)
     }
     
-    /// Adds the `novalidate` attribute to the form, which
-    /// prevents native browser validation on the form.
-    /// - Parameter method: The HTTP request method to use.
+    /// Add the `novalidate` attribute to the form, which
+    /// disables any native browser validation on the form.
+    /// - parameter isOn: Whether validation should be disabled.
     static func novalidate(_ isOn: Bool = true) -> Node {
         isOn ? .attribute(named: "novalidate") : .empty
     }

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -242,7 +242,7 @@ public extension Node where Context == HTML.FormContext {
     /// Adds the `novalidate` attribute to the form, which
     /// prevents native browser validation on the form.
     /// - Parameter method: The HTTP request method to use.
-    static func novalidate(_ isOn: Bool) -> Attribute {
+    static func novalidate(_ isOn: Bool = true) -> Node {
         isOn ? .attribute(named: "novalidate") : .empty
     }
 }

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -331,6 +331,18 @@ final class HTMLTests: XCTestCase {
         """)
     }
     
+    func testFormNoValidate() {
+        let html = HTML(.body(
+            .form(.novalidate())
+            ))
+        
+        assertEqualHTMLContent(html, """
+        <body>\
+        <form novalidate></form>\
+        </body>
+        """)
+    }
+    
     func testHeadings() {
         let html = HTML(.body(
             .h1("One"),
@@ -686,6 +698,7 @@ extension HTMLTests {
             ("testForm", testForm),
             ("testFormContentType", testFormContentType),
             ("testFormMethod", testFormMethod),
+            ("testFormNoValidate", testFormNoValidate),
             ("testHeadings", testHeadings),
             ("testParagraph", testParagraph),
             ("testImage", testImage),

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -334,7 +334,7 @@ final class HTMLTests: XCTestCase {
     func testFormNoValidate() {
         let html = HTML(.body(
             .form(.novalidate())
-            ))
+        ))
         
         assertEqualHTMLContent(html, """
         <body>\


### PR DESCRIPTION
This PR adds support for the `novalidate` form attribute, which [specifies that the form-data (input) should not be validated when submitted](https://www.w3schools.com/tags/att_form_novalidate.asp).