### PR TITLE
Add support for the target attribute in a FormContext

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -238,6 +238,13 @@ public extension Node where Context == HTML.FormContext {
     static func method(_ method: HTMLFormMethod) -> Node {
         .attribute(named: "method", value: method.rawValue)
     }
+    
+    /// Assign a target to the form, specifying where the response
+    /// received after submitting the form should be displayed.
+    /// - parameter target: The target to assign. See `HTMLAnchorTarget`.
+    static func target(_ target: HTMLAnchorTarget) -> Node {
+        .attribute(named: "target", value: target.rawValue)
+    }
 }
 
 public extension Node where Context == HTML.LabelContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -226,6 +226,13 @@ public extension Node where Context == HTML.FormContext {
         .attribute(named: "action", value: url.string)
     }
     
+    /// Assign a target to the form, specifying where the response
+    /// received after submitting the form should be displayed.
+    /// - parameter target: The target to assign. See `HTMLAnchorTarget`.
+    static func target(_ target: HTMLAnchorTarget) -> Node {
+        .attribute(named: "target", value: target.rawValue)
+    }
+    
     /// Assign a specific content type to the form.
     /// - Parameter type: The content type to assign.
     static func enctype(_ type: HTMLFormContentType) -> Node {
@@ -237,13 +244,6 @@ public extension Node where Context == HTML.FormContext {
     /// - Parameter method: The HTTP request method to use.
     static func method(_ method: HTMLFormMethod) -> Node {
         .attribute(named: "method", value: method.rawValue)
-    }
-    
-    /// Assign a target to the form, specifying where the response
-    /// received after submitting the form should be displayed.
-    /// - parameter target: The target to assign. See `HTMLAnchorTarget`.
-    static func target(_ target: HTMLAnchorTarget) -> Node {
-        .attribute(named: "target", value: target.rawValue)
     }
 }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -331,6 +331,20 @@ final class HTMLTests: XCTestCase {
         """)
     }
     
+    func testFormTarget() {
+        let html = HTML(.body(
+            .form(.target(.blank)),
+            .form(.target(.self))
+            ))
+        
+        assertEqualHTMLContent(html, """
+        <body>\
+        <form target="_blank"></form>\
+        <form target="self"></form>\
+        </body>
+        """)
+    }
+    
     func testHeadings() {
         let html = HTML(.body(
             .h1("One"),
@@ -686,6 +700,7 @@ extension HTMLTests {
             ("testForm", testForm),
             ("testFormContentType", testFormContentType),
             ("testFormMethod", testFormMethod),
+            ("testFormTarget", testFormTarget),
             ("testHeadings", testHeadings),
             ("testParagraph", testParagraph),
             ("testImage", testImage),


### PR DESCRIPTION
This PR adds support for the `target` form attribute, which was previously only available in AnchorContext when using Plot. [On forms, it specifies where the response received after submitting the form should be shown.](https://www.w3schools.com/tags/att_form_target.asp)