### PR TITLE
Add support for the aria-hidden accessibility attribute

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -410,6 +410,13 @@ public extension Node where Context: HTML.BodyContext {
     static func ariaExpanded(_ isExpanded: Bool) -> Node {
         .attribute(named: "aria-expanded", value: isExpanded ? "true" : "false")
     }
+    
+    /// Assign an accessibility attribute to an element,
+    /// which removes an element from the accessibility tree
+    /// - parameter isHidden: Whether the element is hidden or not
+    static func ariaHidden(_ isHidden: Bool) -> Node {
+        .attribute(named: "aria-hidden", value: isHidden ? "true" : "false")
+    }
 }
 
 // MARK: - Subresource Integrity

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -601,6 +601,11 @@ final class HTMLTests: XCTestCase {
         let html = HTML(.body(.a(.ariaExpanded(true))))
         assertEqualHTMLContent(html, #"<body><a aria-expanded="true"></a></body>"#)
     }
+    
+    func testAccessibilityHidden() {
+        let html = HTML(.body(.a(.ariaHidden(true))))
+        assertEqualHTMLContent(html, #"<body><a aria-hidden="true"></a></body>"#)
+    }
 
     func testDataAttributes() {
         let html = HTML(.body(
@@ -710,6 +715,7 @@ extension HTMLTests {
             ("testAccessibilityLabel", testAccessibilityLabel),
             ("testAccessibilityControls", testAccessibilityControls),
             ("testAccessibilityExpanded", testAccessibilityExpanded),
+            ("testAccessibilityHidden", testAccessibilityHidden),
             ("testDataAttributes", testDataAttributes),
             ("testSubresourceIntegrity", testSubresourceIntegrity),
             ("testComments", testComments),


### PR DESCRIPTION
This PR adds support for the `aria-hidden` accessibility attribute, which [instructs the browser to remove an element and all of its children from the accessibility tree](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute).

Sorry for sending so many PRs-I just noticed these missing attributes while setting up a site so I thought I'd contribute back 👍 