### PR TITLE
Add support for placeholder attribute on input fields

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -254,6 +254,12 @@ public extension Attribute where Context == HTML.InputContext {
     static func type(_ type: HTMLInputType) -> Attribute {
         Attribute(name: "type", value: type.rawValue)
     }
+    
+    /// Assigns a placeholder to the input field.
+    /// - parameter placeholder: The placeholder to assign.
+    static func placeholder(_ placeholder: String) -> Attribute {
+        Attribute(name: "placeholder", value: placeholder)
+    }
 
     /// Assign whether the element should have autocomplete turned on or off.
     /// - parameter isOn: Whether autocomplete should be turned on.

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -278,7 +278,7 @@ final class HTMLTests: XCTestCase {
                 ),
                 .input(.name("b"), .type(.search), .autocomplete(false), .autofocus(true)),
                 .input(.name("c"), .type(.text), .autofocus(false)),
-                .input(.name("d"), .type(.email), .autocomplete(true), .required(true)),
+                .input(.name("d"), .type(.email), .placeholder("email address"), .autocomplete(true), .required(true)),
                 .textarea(.name("e"), .cols(50), .rows(10), .required(true), .text("Test")),
                 .textarea(.name("f"), .autofocus(true)),
                 .input(.type(.submit), .value("Send"))
@@ -293,7 +293,7 @@ final class HTMLTests: XCTestCase {
         </fieldset>\
         <input name="b" type="search" autocomplete="off" autofocus="true"/>\
         <input name="c" type="text"/>\
-        <input name="d" type="email" autocomplete="on" required="true"/>\
+        <input name="d" type="email" placeholder="email address" autocomplete="on" required="true"/>\
         <textarea name="e" cols="50" rows="10" required="true">Test</textarea>\
         <textarea name="f" autofocus="true"></textarea>\
         <input type="submit" value="Send"/>\


### PR DESCRIPTION
This PR adds support for the `placeholder` attribute on input fields, which [specifies a short hint that describes the expected value of an input field](https://www.w3schools.com/tags/att_input_placeholder.asp).