### PR TITLE
Add viewport-fit to viewport meta tag

### DIFF
--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -86,6 +86,8 @@ public extension Node where Context == HTML.HeadContext {
     /// - parameter widthMode: How the viewport's width should scale according
     ///   to the device the page is being rendered on. See `HTMLViewportWidthMode`.
     /// - parameter initialScale: The initial scale that the page should use.
+    /// - parameter fit: How the viewport should be laid out on screen in relation
+    ///   to the screen’s safe area insets. See `HTMLViewportFitMode`.
     static func viewport(_ widthMode: HTMLViewportWidthMode,
                          initialScale: Double = 1,
                          fit: HTMLViewportFitMode? = nil) -> Node {

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -87,8 +87,12 @@ public extension Node where Context == HTML.HeadContext {
     ///   to the device the page is being rendered on. See `HTMLViewportWidthMode`.
     /// - parameter initialScale: The initial scale that the page should use.
     static func viewport(_ widthMode: HTMLViewportWidthMode,
-                         initialScale: Double = 1) -> Node {
-        let content = "width=\(widthMode.string), initial-scale=\(initialScale)"
+                         initialScale: Double = 1,
+                         viewportFitMode: HTMLViewportFitMode? = nil) -> Node {
+        var content = "width=\(widthMode.string), initial-scale=\(initialScale)"
+        if let viewportFitMode = viewportFitMode {
+            content += ", viewport-fit=\(viewportFitMode.rawValue)"
+        }
         return .meta(.name("viewport"), .content(content))
     }
 

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -88,7 +88,7 @@ public extension Node where Context == HTML.HeadContext {
     /// - parameter initialScale: The initial scale that the page should use.
     static func viewport(_ widthMode: HTMLViewportWidthMode,
                          initialScale: Double = 1,
-                         viewportFitMode: HTMLViewportFitMode? = nil) -> Node {
+                         viewportFit: HTMLViewportFitMode? = nil) -> Node {
         var content = "width=\(widthMode.string), initial-scale=\(initialScale)"
         if let viewportFitMode = viewportFitMode {
             content += ", viewport-fit=\(viewportFitMode.rawValue)"

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -88,10 +88,10 @@ public extension Node where Context == HTML.HeadContext {
     /// - parameter initialScale: The initial scale that the page should use.
     static func viewport(_ widthMode: HTMLViewportWidthMode,
                          initialScale: Double = 1,
-                         viewportFit: HTMLViewportFitMode? = nil) -> Node {
+                         fit: HTMLViewportFitMode? = nil) -> Node {
         var content = "width=\(widthMode.string), initial-scale=\(initialScale)"
-        if let viewportFitMode = viewportFitMode {
-            content += ", viewport-fit=\(viewportFitMode.rawValue)"
+        if let fit = fit {
+            content += ", viewport-fit=\(fit.rawValue)"
         }
         return .meta(.name("viewport"), .content(content))
     }

--- a/Sources/Plot/API/HTMLViewportFitMode.swift
+++ b/Sources/Plot/API/HTMLViewportFitMode.swift
@@ -1,0 +1,22 @@
+/**
+*  Plot
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+import Foundation
+
+/// Enum defining the fit parameters of the viewport meta tag.
+public enum HTMLViewportFitMode: String {
+    /// This value doesn’t affect the initial layout viewport, and the whole web page is viewable.
+    /// What the UA paints outside of the viewport is undefined.
+    /// It may be the background color of the canvas, or anything else that the UA deems appropriate.
+    case auto
+    /// The initial layout viewport and the visual viewport are set to the largest rectangle which is
+    /// inscribed in the display of the device. What the UA paints outside of the viewport is undefined.
+    /// It may be the background color of the canvas, or anything else that the UA deems appropriate.
+    case contain
+    /// The initial layout viewport and the visual viewport
+    /// are set to the circumscribed rectangle of the physical screen of the device.
+    case cover
+}

--- a/Sources/Plot/API/HTMLViewportFitMode.swift
+++ b/Sources/Plot/API/HTMLViewportFitMode.swift
@@ -8,15 +8,12 @@ import Foundation
 
 /// Enum defining the fit parameters of the viewport meta tag.
 public enum HTMLViewportFitMode: String {
-    /// This value doesn’t affect the initial layout viewport, and the whole web page is viewable.
-    /// What the UA paints outside of the viewport is undefined.
-    /// It may be the background color of the canvas, or anything else that the UA deems appropriate.
+    /// The default viewport fit behavior.
     case auto
-    /// The initial layout viewport and the visual viewport are set to the largest rectangle which is
-    /// inscribed in the display of the device. What the UA paints outside of the viewport is undefined.
-    /// It may be the background color of the canvas, or anything else that the UA deems appropriate.
+    /// The initial layout viewport and the visual viewport are set
+    /// to fit within the safe area insets of the screen of the device.
     case contain
-    /// The initial layout viewport and the visual viewport
-    /// are set to the circumscribed rectangle of the physical screen of the device.
+    /// The initial layout viewport and the visual viewport are set
+    /// to the outer rectangle covering the screen, ignoring safe area insets.
     case cover
 }

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -113,6 +113,13 @@ final class HTMLTests: XCTestCase {
         <head><meta name="viewport" content="width=500, initial-scale=1.0"/></head>
         """)
     }
+    
+    func testViewportFit() {
+        let html = HTML(.head(.viewport(.accordingToDevice, fit: .cover)))
+        assertEqualHTMLContent(html, """
+        <head><meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"/></head>
+        """)
+    }
 
     func testFavicon() {
         let html = HTML(.head(.favicon("icon.png")))


### PR DESCRIPTION
`viewport-fit` is important for designing websites for iPhones with notches, see https://webkit.org/blog/7929/designing-websites-for-iphone-x/

Usage:

```swift
.viewport(.accordingToDevice, fit: .cover)
```