### PR TITLE
Add support for the <aside> tag

### DIFF
--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -99,6 +99,12 @@ public extension Node where Context: HTML.BodyContext {
         .element(named: "article", nodes: nodes)
     }
 
+    /// Add a `<aside>` HTML element within the current context.
+    /// - parameter nodes: The element's attributes and child elements.
+    static func aside(_ nodes: Node<HTML.BodyContext>...) -> Node {
+        .element(named: "aside", nodes: nodes)
+    }
+
     /// Add an `<audio>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements.
     static func audio(_ nodes: Node<HTML.AudioContext>...) -> Node {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -729,6 +729,7 @@ extension HTMLTests {
             ("testNoScript", testNoScript),
             ("testNavigation", testNavigation),
             ("testSection", testSection),
+            ("testAside", testAside),
             ("testMain", testMain),
             ("testAccessibilityLabel", testAccessibilityLabel),
             ("testAccessibilityControls", testAccessibilityControls),

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -590,6 +590,11 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, "<body><section>Section</section></body>")
     }
 
+    func testAside() {
+        let html = HTML(.body(.aside("Aside")))
+        assertEqualHTMLContent(html, "<body><aside>Aside</aside></body>")
+    }
+
     func testMain() {
         let html = HTML(.body(.main("Main")))
         assertEqualHTMLContent(html, "<body><main>Main</main></body>")


### PR DESCRIPTION
The <aside> tag defines some content aside from the content it is placed in.

`testAside()` passes successfully.