### PR TITLE
Add the small element.

### DIFF
--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -343,6 +343,12 @@ public extension Node where Context: HTML.BodyContext {
         .element(named: "select", nodes: nodes)
     }
 
+    /// Add a `<small>` HTML element within the current context.
+    /// - parameter nodes: The element's attributes and child elements.
+    static func small(_ nodes: Node<HTML.BodyContext>...) -> Node {
+        .element(named: "small", nodes: nodes)
+    }
+
     /// Add a `<span>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements.
     static func span(_ nodes: Node<HTML.BodyContext>...) -> Node {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -480,7 +480,8 @@ final class HTMLTests: XCTestCase {
             .u("Underlined"),
             .s("Strikethrough"),
             .ins("Inserted"),
-            .del("Deleted")
+            .del("Deleted"),
+            .small("Small")
         ))
 
         assertEqualHTMLContent(html, """
@@ -493,6 +494,7 @@ final class HTMLTests: XCTestCase {
         <s>Strikethrough</s>\
         <ins>Inserted</ins>\
         <del>Deleted</del>\
+        <small>Small</small>\
         </body>
         """)
     }


### PR DESCRIPTION
This might seem like an outdated/visual type element (like `i`, and `b`) but it’s not. It’s for small print and that kind of thing.

HTML spec here: https://html.spec.whatwg.org/#the-small-element