### PR TITLE
Enable attributes to be attached to <hr> elements

### DIFF
--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -249,8 +249,9 @@ public extension Node where Context: HTML.BodyContext {
     }
 
     /// Add a `<hr/>` HTML element within the current context.
-    static func hr() -> Node {
-        .selfClosedElement(named: "hr")
+    /// - parameter attributes: The element's attributes.
+    static func hr(_ attributes: Attribute<HTML.BodyContext>...) -> Node {
+        .selfClosedElement(named: "hr", attributes: attributes)
     }
 
     /// Add an `<i>` HTML element within the current context.

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -598,10 +598,8 @@ final class HTMLTests: XCTestCase {
     }
 
     func testHorizontalLineAttributes() {
-        let html = HTML(.body("One", .hr(.class="alternate"), "Two"))
-        assertEqualHTMLContent(html, """
-        <body>One<hr class="alternate" />Two</body>")
-        """)
+        let html = HTML(.body("One", .hr(.class("alternate")), "Two"))
+        assertEqualHTMLContent(html, #"<body>One<hr class="alternate"/>Two</body>"#)
     }
 
     func testNoScript() {
@@ -769,6 +767,7 @@ extension HTMLTests {
             ("testDetails", testDetails),
             ("testLineBreak", testLineBreak),
             ("testHorizontalLine", testHorizontalLine),
+            ("testHorizontalLineAttributes", testHorizontalLineAttributes),
             ("testNoScript", testNoScript),
             ("testNavigation", testNavigation),
             ("testSection", testSection),

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -597,6 +597,13 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, "<body>One<hr/>Two</body>")
     }
 
+    func testHorizontalLineAttributes() {
+        let html = HTML(.body("One", .hr(.class="alternate"), "Two"))
+        assertEqualHTMLContent(html, """
+        <body>One<hr class="alternate" />Two</body>")
+        """)
+    }
+
     func testNoScript() {
         let html = HTML(.body(.noscript("NoScript")))
         assertEqualHTMLContent(html, "<body><noscript>NoScript</noscript></body>")


### PR DESCRIPTION
Adding just a test to start a discussion on this. It's certainly valid to add all sorts of attributes to a `<hr>` element, with `class` being just one of them.

I'm not entirely sure how to fix this, and almost certainly this test is too specific as I bet there's a lot of the closed elements that can take a great many attributes, but it should be able to be the start of a discussion. 