### PR TITLE
Add title support for HTML body elements

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -43,8 +43,6 @@ public extension HTML {
     enum HeadContext: HTMLContext, HTMLScriptableContext {}
     /// The context within an HTML document's `<body>` element.
     class BodyContext: HTMLStylableContext, HTMLScriptableContext, HTMLImageContainerContext {}
-    /// The context within an HTML `<abbr>` element.
-    final class AbbreviationContext: BodyContext {}
     /// The context within an HTML `<a>` element.
     final class AnchorContext: BodyContext, HTMLLinkableContext {}
     /// The context within an HTML `<audio>` element.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -483,13 +483,3 @@ public extension Node where Context: HTML.BodyContext {
         .attribute(named: "onclick", value: script)
     }
 }
-
-// MARK: - Other, element-specific attributes
-
-public extension Node where Context == HTML.AbbreviationContext {
-    /// Specify the abbreviation's full text through its `title` attribute.
-    /// - parameter title: The title to assign.
-    static func title(_ title: String) -> Node {
-        .attribute(named: "title", value: title)
-    }
-}

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -102,6 +102,15 @@ public extension Node where Context == HTML.DocumentContext {
     }
 }
 
+// MARK: - Body
+public extension Node where Context == HTML.BodyContext {
+    /// Specify a title for the element.
+    /// - parameter class: The title for the element.
+    static func title(_ title: String) -> Node {
+        .attribute(named: "title", value: title)
+    }
+}
+
 // MARK: - Links
 
 public extension Attribute where Context == HTML.LinkContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -103,9 +103,10 @@ public extension Node where Context == HTML.DocumentContext {
 }
 
 // MARK: - Body
+
 public extension Node where Context == HTML.BodyContext {
     /// Specify a title for the element.
-    /// - parameter class: The title for the element.
+    /// - parameter title: The title to assign to the element.
     static func title(_ title: String) -> Node {
         .attribute(named: "title", value: title)
     }

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -104,7 +104,7 @@ public extension Node where Context == HTML.DocumentContext {
 
 // MARK: - Body
 
-public extension Node where Context == HTML.BodyContext {
+public extension Node where Context: HTML.BodyContext {
     /// Specify a title for the element.
     /// - parameter title: The title to assign to the element.
     static func title(_ title: String) -> Node {

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -89,7 +89,7 @@ public extension Node where Context: HTML.BodyContext {
 
     /// Add an `<abbr>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements.
-    static func abbr(_ nodes: Node<HTML.AbbreviationContext>...) -> Node {
+    static func abbr(_ nodes: Node<HTML.BodyContext>...) -> Node {
         .element(named: "abbr", nodes: nodes)
     }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -190,6 +190,20 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, #"<body class="b"></body>"#)
     }
 
+    func testTitleAttribute() {
+        let html = HTML(.body(
+            .div(.title("Division title"),
+                .p(.title("Paragraph title"), "Paragraph")
+        )))
+        assertEqualHTMLContent(html, """
+        <body>\
+        <div title="Division title">\
+        <p title="Paragraph title">Paragraph</p>\
+        </div>\
+        </body>
+        """)
+    }
+
     func testUnorderedList() {
         let html = HTML(.body(.ul(.li("Text"))))
         assertEqualHTMLContent(html, "<body><ul><li>Text</li></ul></body>")
@@ -733,6 +747,7 @@ extension HTMLTests {
             ("testBodyWithID", testBodyWithID),
             ("testBodyWithCSSClass", testBodyWithCSSClass),
             ("testOverridingBodyCSSClass", testOverridingBodyCSSClass),
+            ("testTitleAttribute", testTitleAttribute),
             ("testUnorderedList", testUnorderedList),
             ("testOrderedList", testOrderedList),
             ("testDescriptionList", testDescriptionList),

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -195,7 +195,9 @@ final class HTMLTests: XCTestCase {
             .div(.title("Division title"),
                 .p(.title("Paragraph title"), "Paragraph"),
                 .a(.href("#"), .title("Link title"), "Link")
-        )))
+            )
+        ))
+        
         assertEqualHTMLContent(html, """
         <body>\
         <div title="Division title">\

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -602,6 +602,13 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, "<body><noscript>NoScript</noscript></body>")
     }
 
+    func testDivWithTitleAttribute() {
+        let html = HTML(.body(.div("Element"), .title("Title")))
+        assertEqualHTMLContent(html, """
+        <body><div title="Title">Element</div></body>
+        """)
+    }
+
     func testNavigation() {
         let html = HTML(.body(.nav("Navigation")))
         assertEqualHTMLContent(html, "<body><nav>Navigation</nav></body>")

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -193,12 +193,14 @@ final class HTMLTests: XCTestCase {
     func testTitleAttribute() {
         let html = HTML(.body(
             .div(.title("Division title"),
-                .p(.title("Paragraph title"), "Paragraph")
+                .p(.title("Paragraph title"), "Paragraph"),
+                .a(.href("#"), .title("Link title"), "Link")
         )))
         assertEqualHTMLContent(html, """
         <body>\
         <div title="Division title">\
         <p title="Paragraph title">Paragraph</p>\
+        <a href="#" title="Link title">Link</a>\
         </div>\
         </body>
         """)

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -602,13 +602,6 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, "<body><noscript>NoScript</noscript></body>")
     }
 
-    func testDivWithTitleAttribute() {
-        let html = HTML(.body(.div("Element"), .title("Title")))
-        assertEqualHTMLContent(html, """
-        <body><div title="Title">Element</div></body>
-        """)
-    }
-
     func testNavigation() {
         let html = HTML(.body(.nav("Navigation")))
         assertEqualHTMLContent(html, "<body><nav>Navigation</nav></body>")


### PR DESCRIPTION
Again, more to start a discussion than anything. I'm sure this test is way too specific, but `<div>` elements should be able to accept `title` attributes.