### PR TITLE
(feat) added label attribute to \<option\>

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -335,6 +335,12 @@ public extension Attribute where Context == HTML.OptionContext {
             ignoreIfValueIsEmpty: false
         )
     }
+
+    /// Assign a label to the given option.
+    /// - parameter label: The user displayed value of the option
+    static func label(_ label: String) -> Attribute {
+        Attribute(name: "label", value: label, ignoreIfValueIsEmpty: false)
+    }
 }
 
 // MARK: - Layout and styling

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -585,14 +585,14 @@ final class HTMLTests: XCTestCase {
             ),
             .select(
                 .option(.value("C"), .isSelected(true)),
-                .option(.value("D"), .isSelected(false))
+                .option(.value("D"), .label("Dee"), .isSelected(false))
             )
         ))
 
         assertEqualHTMLContent(html, """
         <body>\
         <datalist><option value="A"/><option value="B"/></datalist>\
-        <select><option value="C" selected/><option value="D"/></select>\
+        <select><option value="C" selected/><option value="D" label="Dee"/></select>\
         </body>
         """)
     }


### PR DESCRIPTION
The label attribute allows you to show the user a label other than the underlying form value

https://html.spec.whatwg.org/#the-option-element