### PR TITLE
SPM dependency reference fix for Swift 5.3/Xcode 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Plot is distributed using the [Swift Package Manager](https://swift.org/package-
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/johnsundell/plot.git", from: "0.1.0")
+        .package(name: "Plot", url: "https://github.com/johnsundell/plot.git", from: "0.1.0")
     ],
     ...
 )


### PR DESCRIPTION
The current documentation for adding the package doesn't work in Xcode 12. I propose a fix which is supported by Xcode 12.