### PR TITLE
Added the ability to add gtag for Google Analytics

### DIFF
--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -76,6 +76,15 @@ public extension Node where Context == HTML.HeadContext {
     static func style(_ css: String) -> Node {
         .element(named: "style", nodes: [.raw(css)])
     }
+    
+    /// Add a `<script/>` HTML element within the current context.
+    /// - parameter trackingID: The tracking ID for your website provided by Google Analytics.
+    static func gTag(_ trackingID: String) -> Node {
+        return group([
+            .script(.async(), .src("https://www.googletagmanager.com/gtag/js?id=\(trackingID)")),
+            .script("window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '\(trackingID)');")
+        ])
+    }
 }
 
 // MARK: - Body

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -771,6 +771,16 @@ final class HTMLTests: XCTestCase {
         <body><div onclick="javascript:alert('Hello World')"></div></body>
         """)
     }
+    
+    func testGtag() {
+        let html = HTML(.head(
+            .gTag("ID-1234567890-0")
+            )
+        )
+        assertEqualHTMLContent(html, """
+        <head><script async src="https://www.googletagmanager.com/gtag/js?id=ID-1234567890-0"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'ID-1234567890-0');</script></head>
+        """)
+    }
 }
 
 extension HTMLTests {
@@ -843,7 +853,8 @@ extension HTMLTests {
             ("testSubresourceIntegrity", testSubresourceIntegrity),
             ("testComments", testComments),
             ("testPicture", testPicture),
-            ("testOnClick", testOnClick)
+            ("testOnClick", testOnClick),
+            ("testGtag", testGtag)
         ]
     }
 }


### PR DESCRIPTION
I noticed there was no ability to add tracking built into Publish when working on my website. I went ahead and created a custom node to add to the head that allows you to pass in your tracking ID that Google provides for Google Analytics and it will create the gtag automatically. It works successfully on my personal site and passes the unit test here. 