### PR TITLE
Make img tag supports width and height attribute

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -68,7 +68,7 @@ public extension HTML {
     /// The context within an HTML `<iframe>` element.
     enum IFrameContext: HTMLNamableContext, HTMLSourceContext {}
     /// The context within an HTML `<img>` element.
-    enum ImageContext: HTMLSourceContext, HTMLStylableContext {}
+    enum ImageContext: HTMLSourceContext, HTMLStylableContext, HTMLDimensionContext {}
     /// The context within an HTML `<input>` element.
     enum InputContext: HTMLNamableContext, HTMLValueContext {}
     /// The context within an HTML `<textarea>` element.

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -456,12 +456,14 @@ final class HTMLTests: XCTestCase {
                 .id("id"),
                 .class("image"),
                 .src("image.png"),
-                .alt("Text")
+                .alt("Text"),
+                .width(44),
+                .height(44)
             )
         ))
 
         assertEqualHTMLContent(html, """
-        <body><img id="id" class="image" src="image.png" alt="Text"/></body>
+        <body><img id="id" class="image" src="image.png" alt="Text" width="44" height="44"/></body>
         """)
     }
 


### PR DESCRIPTION
`<img>` tag works with `width` and `height` attribute. And will set the image dimension in px. Make the `ImageContext` adopt `HTMLDimensionContext` so we could change the image size without CSS.

```
.img(
    .src("/images/sample.png"),
    .width(44),
    .height(44)
)
```