### PR TITLE
Add Node-a-href-overload

### DIFF
--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -87,6 +87,15 @@ public extension Node where Context: HTML.BodyContext {
         .element(named: "a", nodes: nodes)
     }
 
+    /// Add an `<a>` HTML element within the current context.
+    /// - Parameters:
+    ///   - href: The URL to assign.
+    ///   - nodes: The element's attributes and child elements.
+    static func a(href url: URLRepresentable, _ nodes: Node<HTML.BodyContext>...) -> Node {
+        .element(named: "a",
+                 nodes: [.attribute(named: "href", value: url.string)] + nodes)
+    }
+
     /// Add an `<abbr>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements.
     static func abbr(_ nodes: Node<HTML.BodyContext>...) -> Node {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -233,7 +233,8 @@ final class HTMLTests: XCTestCase {
         let html = try HTML(.body(
             .a(.href("a.html"), .target(.blank), .text("A")),
             .a(.href("b.html"), .rel(.nofollow), .text("B")),
-            .a(.href(require(URL(string: "c.html"))), .text("C"))
+            .a(.href(require(URL(string: "c.html"))), .text("C")),
+            .a(href: "d.html", .text("D"))
         ))
 
         assertEqualHTMLContent(html, """
@@ -241,6 +242,7 @@ final class HTMLTests: XCTestCase {
         <a href="a.html" target="_blank">A</a>\
         <a href="b.html" rel="nofollow">B</a>\
         <a href="c.html">C</a>\
+        <a href="d.html">D</a>\
         </body>
         """)
     }


### PR DESCRIPTION
Hi John, we've run into a situation where we want to wrap a piece of content conditionally into a `a href=` and ran into an issue with type mismatch between `Node<BodyContext>` and `Node<AnchorContext>`.

Here's a playground illustrating the issue:

```
import Foundation
import Plot

extension Node where Context: HTML.BodyContext {
    static func a(href url: URLRepresentable, _ nodes: Node<HTML.BodyContext>...) -> Node {
        .element(named: "a", nodes: [
            // 'string' is inaccessible due to 'internal' protection level
            //    .attribute(named: "href", value: url.string)
            // add to Plot for access
            .attribute(named: "href", value: url.description)
        ] + nodes)
    }
}


func content() -> Node<HTML.BodyContext> {
    "content"
}


/*
func license(url: URL?) -> Node<HTML.BodyContext> {
    .unwrap(url,
            // Cannot convert value of type 'Node<HTML.BodyContext>' to expected argument type 'Node<HTML.AnchorContext>'
            { .a( .href($0), content()) },
            else: content())
}
*/

func license(url: URL?) -> Node<HTML.BodyContext> {
    .unwrap(url,
            { .a(href: $0, content()) },
            else: content())
}

print(license(url: URL(string: "https://foo/bar")).render())  // <a href="https://foo/bar">content</a>
print(license(url: nil).render())                             // content
```

We have some dynamic content generated by `content()` which needs to be `BodyContext`. However, using it in `.a(.href(...), ...)` is not possible, because it requires `AnchorContext` input.

I believe this is overly strict: the only piece of `nodes` in `a(_ nodes: Node<HTML.AnchorContext>...)` that actually requires `AnchorContext` is `.href`. So I think it might make sense to add an overload that peels `href` off, allowing the rest of the `nodes` to be `BodyContext`.

Of course, it could also be that I'm overlooking a mechanism to upgrade the types as needed without any changes :)

In any case, we could add our own extension to handle this case but since the `URLRepresentable` extension on `URL`, `string`, is internal we have to use `description` directly instead.

If you agree that this change makes sense it would be better to use the proper protocol extension that you're shipping instead.