### PR TITLE
Fix empty alt attribute rendering

### DIFF
--- a/Sources/Plot/API/Attribute.swift
+++ b/Sources/Plot/API/Attribute.swift
@@ -11,21 +11,29 @@ import Foundation
 /// but rather use Plot's various DSL APIs to create them, for example by using
 /// the `id()` or `class()` modifier on an HTML element.
 public struct Attribute<Context> {
+    public enum EmptyValueRenderingBehaviour {
+        /// Attribute is completely ignored
+        case ignore
+        /// Only the name of attribute is rendered
+        case renderJustName
+        /// Attribute is rendered with empty value
+        case renderEmptyValue
+    }
     /// The name of the attribute
     public var name: String
     /// The attribute's value
     public var value: String?
-    /// Whether the attribute should be completely ignored if it has no value
-    public var ignoreIfValueIsEmpty: Bool
+    /// Defines how attribute is rendered if it's value is empty
+    public var ifValueIsEmpty: EmptyValueRenderingBehaviour
 
     /// Create a new `Attribute` instance with a name and a value, and optionally
     /// opt out of ignoring the attribute if its value is empty.
     public init(name: String,
                 value: String?,
-                ignoreIfValueIsEmpty: Bool = true) {
+                ifValueIsEmpty: EmptyValueRenderingBehaviour = .ignore) {
         self.name = name
         self.value = value
-        self.ignoreIfValueIsEmpty = ignoreIfValueIsEmpty
+        self.ifValueIsEmpty = ifValueIsEmpty
     }
 }
 
@@ -59,7 +67,14 @@ internal protocol AnyAttribute {
 extension Attribute: AnyAttribute {
     func render() -> String {
         guard let value = value, !value.isEmpty else {
-            return ignoreIfValueIsEmpty ? "" : name
+            switch ifValueIsEmpty {
+            case .ignore:
+                return ""
+            case .renderJustName:
+                return name
+            case .renderEmptyValue:
+                return #"\#(name)="""#
+            }
         }
 
         return "\(name)=\"\(value)\""

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -332,14 +332,14 @@ public extension Attribute where Context == HTML.OptionContext {
         return Attribute(
             name: "selected",
             value: nil,
-            ignoreIfValueIsEmpty: false
+            ifValueIsEmpty: .renderJustName
         )
     }
 
     /// Assign a label to the given option.
     /// - parameter label: The user displayed value of the option
     static func label(_ label: String) -> Attribute {
-        Attribute(name: "label", value: label, ignoreIfValueIsEmpty: false)
+        Attribute(name: "label", value: label, ifValueIsEmpty: .renderJustName)
     }
 }
 
@@ -412,7 +412,7 @@ public extension Attribute where Context == HTML.ImageContext {
     /// accessibility, and in case the referenced image can't be rendered.
     /// - parameter text: The alternative text to use.
     static func alt(_ text: String) -> Attribute {
-        Attribute(name: "alt", value: text)
+        Attribute(name: "alt", value: text, ifValueIsEmpty: .renderEmptyValue)
     }
 }
 
@@ -471,12 +471,12 @@ public extension Node where Context: HTMLIntegrityContext {
 public extension Node where Context == HTML.ScriptContext {
     /// Assign that the element's script should be loaded in `async` mode.
     static func async() -> Node {
-        .attribute(named: "async", value: nil, ignoreIfValueIsEmpty: false)
+        .attribute(named: "async", value: nil, ifValueIsEmpty: .renderJustName)
     }
     
     /// Assign that the element's script should be loaded in `defer` mode.
     static func `defer`() -> Node {
-        .attribute(named: "defer", value: nil, ignoreIfValueIsEmpty: false)
+        .attribute(named: "defer", value: nil, ifValueIsEmpty: .renderJustName)
     }
 }
 

--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -97,7 +97,7 @@ public extension Node {
         .attribute(Attribute(
             name: name,
             value: nil,
-            ignoreIfValueIsEmpty: false
+            ifValueIsEmpty: .renderJustName
         ))
     }
 
@@ -108,11 +108,11 @@ public extension Node {
     ///   its value is empty (default: true).
     static func attribute(named name: String,
                           value: String?,
-                          ignoreIfValueIsEmpty: Bool = true) -> Node {
+                          ifValueIsEmpty: Attribute<Context>.EmptyValueRenderingBehaviour = .ignore) -> Node {
         .attribute(Attribute(
             name: name,
             value: value,
-            ignoreIfValueIsEmpty: ignoreIfValueIsEmpty
+            ifValueIsEmpty: ifValueIsEmpty
         ))
     }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -467,6 +467,19 @@ final class HTMLTests: XCTestCase {
         """)
     }
 
+    func testImageWithEmptyAlt() {
+        let html = HTML(.body(
+            .img(
+                .src("image.png"),
+                .alt("")
+            )
+        ))
+
+        assertEqualHTMLContent(html, """
+        <body><img src="image.png" alt=""/></body>
+        """)
+    }
+
     func testAudioPlayer() {
         let html = HTML(.body(
             .audio(.source(.src("a.mp3"), .type(.mp3))),
@@ -817,6 +830,7 @@ extension HTMLTests {
             ("testHeadings", testHeadings),
             ("testParagraph", testParagraph),
             ("testImage", testImage),
+            ("testImageWithEmptyAlt", testImageWithEmptyAlt),
             ("testAudioPlayer", testAudioPlayer),
             ("testVideoPlayer", testVideoPlayer),
             ("testArticle", testArticle),


### PR DESCRIPTION
After performing site scan with Lighthouse, I found that `alt` attributes with empty values aren't being rendered, [despite it being correct value: ](https://html.spec.whatwg.org/multipage/images.html#a-purely-decorative-image-that-doesn't-add-any-information)
> However, a decorative image that isn't discussed by the surrounding text but still has some relevance can be included in a page using the img element. Such images are decorative, but still form part of the content. In these cases, the alt attribute must be present but its value must be the empty string.

This is my first OSS contribution, so excuse me if I've done anything incorrectly. I am not sure if the approach that I chose is the right one - extra condition in `render()` like 
```swift
guard let value = value, !value.isEmpty else {
    if (Context.self == HTML.ImageContext.self && name == "alt")  {
        return #"alt="""#
    } else {
         return ignoreIfValueIsEmpty ? "" : name
    }
}
```
 would also do the job, though it doesn't feel right. Also, since my solution is breaking change, I am wondering if I should keep the old init, depreciate it and make it call new init like:
 ```swift
@available(*, deprecated, message: "Please use init(name:_,value:_,ifValueIsEmpty:_) instead.")
public init(name: String,
             value: String?,
             ignoreIfValueIsEmpty: Bool = true) {
    self.init(name: name, value: value, ifValueIsEmpty: ignoreIfValueIsEmpty ? .ignore : .renderJustName)
}
```