### PR TITLE
Fix RSS 'content' namespace.

### DIFF
--- a/Sources/Plot/API/RSS.swift
+++ b/Sources/Plot/API/RSS.swift
@@ -89,7 +89,7 @@ internal extension Document where Format: RSSBasedDocumentFormat {
             .rss(
                 .version(2.0),
                 .namespace("atom", "http://www.w3.org/2005/Atom"),
-                .namespace("content", "http://purl.org/rss/1.0/modules/content"),
+                .namespace("content", "http://purl.org/rss/1.0/modules/content/"),
                 .group(nodes)
             )
         ])

--- a/Tests/PlotTests/Assertions.swift
+++ b/Tests/PlotTests/Assertions.swift
@@ -140,7 +140,7 @@ func assertEqualPodcastFeedContent(
         type: "podcast",
         namespaces: [
             ("atom", "http://www.w3.org/2005/Atom"),
-            ("content", "http://purl.org/rss/1.0/modules/content"),
+            ("content", "http://purl.org/rss/1.0/modules/content/"),
             ("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"),
             ("media", "http://www.rssboard.org/media-rss")
         ],
@@ -161,7 +161,7 @@ func assertEqualRSSFeedContent(
         type: "RSS",
         namespaces: [
             ("atom", "http://www.w3.org/2005/Atom"),
-            ("content", "http://purl.org/rss/1.0/modules/content")
+            ("content", "http://purl.org/rss/1.0/modules/content/")
         ],
         file: file,
         line: line


### PR DESCRIPTION
When validating generated RSS content with the [_W3C Feed Validation Service_](https://validator.w3.org/feed/), a recommendation is issued that the _content_ namespace should be `http://purl.org/rss/1.0/modules/content/`.

The namespace generated by _Plot_ is `http://purl.org/rss/1.0/modules/content` and doesn't contain the trailing slash. 

This fix appends the trailing slash to the _content_ namespace so that the validator will not issue this warning/recommendation anymore. 