### PR TITLE
Prevent empty attribute values from being appended

### DIFF
--- a/Sources/Plot/API/Attribute.swift
+++ b/Sources/Plot/API/Attribute.swift
@@ -64,7 +64,7 @@ extension Attribute: NodeConvertible {
 
 extension Attribute: AnyAttribute {
     func render() -> String {
-        guard let value = value, !value.isEmpty else {
+        guard let value = nonEmptyValue else {
             return ignoreIfValueIsEmpty ? "" : name
         }
 

--- a/Sources/Plot/Internal/AnyAttribute.swift
+++ b/Sources/Plot/Internal/AnyAttribute.swift
@@ -11,3 +11,9 @@ internal protocol AnyAttribute {
 
     func render() -> String
 }
+
+extension AnyAttribute {
+    var nonEmptyValue: String? {
+        value?.isEmpty == false ? value : nil
+    }
+}

--- a/Sources/Plot/Internal/ElementRenderingBuffer.swift
+++ b/Sources/Plot/Internal/ElementRenderingBuffer.swift
@@ -22,11 +22,7 @@ internal final class ElementRenderingBuffer {
         if let existingIndex = attributeIndexes[attribute.name] {
             if attribute.replaceExisting {
                 attributes[existingIndex].value = attribute.value
-            } else {
-                guard let newValue = attribute.nonEmptyValue else {
-                    return
-                }
-
+            } else if let newValue = attribute.nonEmptyValue {
                 if let existingValue = attributes[existingIndex].nonEmptyValue {
                     attributes[existingIndex].value = existingValue + " " + newValue
                 } else {

--- a/Sources/Plot/Internal/ElementRenderingBuffer.swift
+++ b/Sources/Plot/Internal/ElementRenderingBuffer.swift
@@ -20,12 +20,18 @@ internal final class ElementRenderingBuffer {
 
     func add(_ attribute: AnyAttribute) {
         if let existingIndex = attributeIndexes[attribute.name] {
-            if !attribute.replaceExisting,
-               let existingValue = attributes[existingIndex].value,
-               let newValue = attribute.value {
-                attributes[existingIndex].value = existingValue + " " + newValue
-            } else {
+            if attribute.replaceExisting {
                 attributes[existingIndex].value = attribute.value
+            } else {
+                guard let newValue = attribute.nonEmptyValue else {
+                    return
+                }
+
+                if let existingValue = attributes[existingIndex].nonEmptyValue {
+                    attributes[existingIndex].value = existingValue + " " + newValue
+                } else {
+                    attributes[existingIndex].value = newValue
+                }
             }
         } else {
             attributeIndexes[attribute.name] = attributes.count

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -88,6 +88,17 @@ final class HTMLComponentTests: XCTestCase {
         XCTAssertEqual(html, #"<p class="one two three">Hello</p>"#)
     }
 
+    func testNotAppendingEmptyClassNames() {
+        let html = Paragraph("Hello")
+            .class("")
+            .class("one")
+            .class("")
+            .class("two")
+            .render()
+
+        XCTAssertEqual(html, #"<p class="one two">Hello</p>"#)
+    }
+
     func testReplacingClass() {
         let html = Paragraph("Hello")
             .class("one")


### PR DESCRIPTION
When adding an attribute that should be appended to any existing one, first check if either the existing or new attribute contain an empty value, and if so, don't perform the append. Otherwise, we'll end up with extra whitespace within attribute values. Also, slight cleanup of the attribute handling logic within `ElementRenderingBuffer`, to make the conditionals a bit more clear.