### PR TITLE
Make it possible to add attributes to wrapper components

### DIFF
--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -175,7 +175,7 @@ internal extension Node where Context == Any {
     static func modifiedComponent(_ component: ModifiedComponent) -> Node {
         Node { renderer in
             renderer.renderComponent(component.base,
-                deferredAttributes: component.deferredAttributes,
+                deferredAttributes: component.deferredAttributes + renderer.deferredAttributes,
                 environmentOverrides: component.environmentOverrides
             )
         }

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -88,7 +88,7 @@ final class HTMLComponentTests: XCTestCase {
         XCTAssertEqual(html, #"<p class="one two three">Hello</p>"#)
     }
 
-    func testNotAppendingEmptyClassNames() {
+    func testNotAppendingEmptyClasses() {
         let html = Paragraph("Hello")
             .class("")
             .class("one")
@@ -97,6 +97,23 @@ final class HTMLComponentTests: XCTestCase {
             .render()
 
         XCTAssertEqual(html, #"<p class="one two">Hello</p>"#)
+    }
+
+    func testAppendingClassesToWrappingComponents() {
+        struct InnerWrapper: Component {
+            var body: Component {
+                Paragraph("Hello").class("one")
+            }
+        }
+
+        struct OuterWrapper: Component {
+            var body: Component {
+                InnerWrapper().class("two")
+            }
+        }
+
+        let html = OuterWrapper().class("three").render()
+        XCTAssertEqual(html, #"<p class="one two three">Hello</p>"#)
     }
 
     func testReplacingClass() {


### PR DESCRIPTION
When an attribute is added to a component that acts as a wrapper for an element-based component, that attribute is now added directly to the wrapped, underlying element. That makes it possible to append things like class names to existing, custom components.