### PR TITLE
Enable attributes to be appended to members of nested component groups

### DIFF
--- a/Sources/Plot/API/Node.swift
+++ b/Sources/Plot/API/Node.swift
@@ -184,7 +184,9 @@ internal extension Node where Context == Any {
     static func components(_ components: [Component]) -> Node {
         Node { renderer in
             components.forEach {
-                renderer.renderComponent($0)
+                renderer.renderComponent($0,
+                    deferredAttributes: renderer.deferredAttributes
+                )
             }
         }
     }

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -116,6 +116,21 @@ final class HTMLComponentTests: XCTestCase {
         XCTAssertEqual(html, #"<p class="one two three">Hello</p>"#)
     }
 
+    func testAppendingClassToWrappingComponentContainingGroup() {
+        struct Wrapper: Component {
+            var body: Component {
+                ComponentGroup {
+                    Paragraph("One")
+                    Paragraph("Two")
+                }
+                .class("one")
+            }
+        }
+
+        let html = Wrapper().class("two").render()
+        XCTAssertEqual(html, #"<p class="one two">One</p><p class="one two">Two</p>"#)
+    }
+
     func testReplacingClass() {
         let html = Paragraph("Hello")
             .class("one")


### PR DESCRIPTION
Make it possible to append attributes to the member elements of a `ComponentGroup`, when such a group is nested within a custom wrapper component.