### PR TITLE
Fix text rendering regression for indented documents

### DIFF
--- a/Sources/Plot/Internal/ElementRenderingBuffer.swift
+++ b/Sources/Plot/Internal/ElementRenderingBuffer.swift
@@ -35,8 +35,8 @@ internal final class ElementRenderingBuffer {
         }
     }
 
-    func add(_ text: String) {
-        if indentation != nil {
+    func add(_ text: String, isPlainText: Bool) {
+        if !isPlainText, indentation != nil {
             body.append("\n")
         }
 

--- a/Tests/PlotTests/DocumentTests.swift
+++ b/Tests/PlotTests/DocumentTests.swift
@@ -26,9 +26,16 @@ final class DocumentTests: XCTestCase {
                     .element(named: "two", nodes: [
                         .selfClosedElement(named: "three")
                     ]),
-                    .element(named: "four")
+                    .text("four "),
+                    .component(Text("five")),
+                    .component(Element.named("six", nodes: [
+                        .text("seven")
+                    ])),
+                    .element(named: "eight", nodes: [
+                        .text("nine")
+                    ])
                 ]),
-                .selfClosed(named: "five", attributes: [
+                .selfClosed(named: "ten", attributes: [
                     Attribute(name: "key", value: "value")
                 ])
             ]
@@ -38,10 +45,11 @@ final class DocumentTests: XCTestCase {
         <one>
             <two>
                 <three/>
-            </two>
-            <four></four>
+            </two>four five
+            <six>seven</six>
+            <eight>nine</eight>
         </one>
-        <five key="value"/>
+        <ten key="value"/>
         """)
     }
 


### PR DESCRIPTION
Plot 0.9.0 introduced a minor regression for documents that are rendered with indentation, in that plain text nodes would always be rendered on a new line. This patch fixes that by differentiating between plain text output and element-based output, and only the latter causes a new line to be inserted, preserving the previous rendering behavior.

Components that are made up of just plain text also get this behavior, and the unit test that verifies indented documents has been expanded to also cover these cases.