### PR TITLE
Boolean attributes

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -451,7 +451,7 @@ public extension Attribute where Context == HTML.IFrameContext {
     /// Assign whether to grant the iframe full screen capabilities.
     /// - parameter allow: Whether the iframe should be allowed to go full screen.
     static func allowfullscreen(_ allow: Bool) -> Attribute {
-        Attribute(name: "allowfullscreen", value: String(allow))
+        Attribute(name: "allowfullscreen", value: nil, ignoreIfValueIsEmpty: false)
     }
 }
 

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -74,6 +74,12 @@ public extension Node where Context: HTMLContext {
     static func title(_ title: String) -> Node {
         .attribute(named: "title", value: title)
     }
+
+    /// Assign whether the element should be hidden.
+    /// - parameter isHidden: Whether the element should be hidden or not.
+    static func hidden(_ isHidden: Bool) -> Node {
+        isHidden ? .attribute(named: "hidden") : .empty
+    }
 }
 
 public extension Attribute where Context: HTMLNamableContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -194,8 +194,8 @@ public extension Node where Context == HTML.AnchorContext {
 // MARK: - Interactive elements
 
 public extension Node where Context == HTML.DetailsContext {
-    /// Assign whether the details element should be displayed as open.
-    /// - parameter isOpen: Whether the element is required.
+    /// Assign whether the details element is opened/expanded.
+    /// - parameter isOpen: Whether the element should be displayed as open.
     static func open(_ isOpen: Bool) -> Node {
         isOpen ? .attribute(named: "open") : .empty
     }

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -343,6 +343,12 @@ public extension Attribute where Context == HTML.InputContext {
     static func multiple(_ isMultiple: Bool) -> Attribute {
         isMultiple ? Attribute(name: "multiple", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
+
+    /// Assign whether a checkbox or radio input element has an active state.
+    /// - parameter isChecked: Whether the element has an active state.
+    static func checked(_ isChecked: Bool) -> Attribute {
+        isChecked ? Attribute(name: "checked", value: nil, ignoreIfValueIsEmpty: false) : .empty
+    }
 }
 
 public extension Node where Context == HTML.TextAreaContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -473,7 +473,7 @@ public extension Attribute where Context == HTML.IFrameContext {
     /// Assign whether to grant the iframe full screen capabilities.
     /// - parameter allow: Whether the iframe should be allowed to go full screen.
     static func allowfullscreen(_ allow: Bool) -> Attribute {
-        Attribute(name: "allowfullscreen", value: nil, ignoreIfValueIsEmpty: false)
+        allow ? Attribute(name: "allowfullscreen", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
 }
 

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -185,6 +185,16 @@ public extension Node where Context == HTML.AnchorContext {
     }
 }
 
+// MARK: - Interactive elements
+
+public extension Node where Context == HTML.DetailsContext {
+    /// Assign whether the details element should be displayed as open.
+    /// - parameter isOpen: Whether the element is required.
+    static func open(_ isOpen: Bool) -> Node {
+        isOpen ? .attribute(named: "open") : .empty
+    }
+}
+
 // MARK: - Sources and media
 
 public extension Attribute where Context: HTMLSourceContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -302,7 +302,7 @@ public extension Attribute where Context == HTML.InputContext {
         Attribute(name: "type", value: type.rawValue)
     }
     
-    /// Assigns a placeholder to the input field.
+    /// Assign a placeholder to the input field.
     /// - parameter placeholder: The placeholder to assign.
     static func placeholder(_ placeholder: String) -> Attribute {
         Attribute(name: "placeholder", value: placeholder)
@@ -364,7 +364,7 @@ public extension Node where Context == HTML.TextAreaContext {
         .attribute(named: "rows", value: String(rows))
     }
     
-    /// Assigns a placeholder to the text area.
+    /// Assign a placeholder to the text area.
     /// - parameter placeholder: The placeholder to assign.
     static func placeholder(_ placeholder: String) -> Node {
         .attribute(named: "placeholder", value: placeholder)

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -353,6 +353,18 @@ public extension Node where Context == HTML.TextAreaContext {
     static func autofocus(_ isOn: Bool) -> Node {
         isOn ? .attribute(named: "autofocus") : .empty
     }
+
+    /// Assign whether the element should be read-only.
+    /// - parameter isReadonly: Whether the input is read-only.
+    static func readonly(_ isReadonly: Bool) -> Node {
+        isReadonly ? .attribute(named: "readonly") : .empty
+    }
+
+    /// Assign whether the element should be disabled.
+    /// - parameter isDisabled: Whether the input is disabled.
+    static func disabled(_ isDisabled: Bool) -> Node {
+        isDisabled ? .attribute(named: "disabled") : .empty
+    }
 }
 
 public extension Attribute where Context == HTML.OptionContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -342,6 +342,12 @@ public extension Node where Context == HTML.TextAreaContext {
         .attribute(named: "rows", value: String(rows))
     }
     
+    /// Assigns a placeholder to the text area.
+    /// - parameter placeholder: The placeholder to assign.
+    static func placeholder(_ placeholder: String) -> Node {
+        .attribute(named: "placeholder", value: placeholder)
+    }
+
     /// Assign whether the element is required before submitting the form.
     /// - parameter isRequired: Whether the element is required.
     static func required(_ isRequired: Bool) -> Node {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -340,8 +340,8 @@ public extension Attribute where Context == HTML.InputContext {
 
     /// Assign whether the element should allow the selection of multiple values.
     /// - parameter isMultiple: Whether multiple values are allowed.
-    static func multiple(_ isMultiple: Bool) -> Attribute {
-        isMultiple ? Attribute(name: "multiple", value: nil, ignoreIfValueIsEmpty: false) : .empty
+    static func multiple(_ isEnabled: Bool) -> Attribute {
+        isEnabled ? Attribute(name: "multiple", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
 
     /// Assign whether a checkbox or radio input element has an active state.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -309,6 +309,24 @@ public extension Attribute where Context == HTML.InputContext {
     static func autofocus(_ isOn: Bool) -> Attribute {
         isOn ? Attribute(name: "autofocus", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
+
+    /// Assign whether the element should be read-only.
+    /// - parameter isReadonly: Whether the input is read-only.
+    static func readonly(_ isReadonly: Bool) -> Attribute {
+        isReadonly ? Attribute(name: "readonly", value: nil, ignoreIfValueIsEmpty: false) : .empty
+    }
+
+    /// Assign whether the element should be disabled.
+    /// - parameter isDisabled: Whether the input is disabled.
+    static func disabled(_ isDisabled: Bool) -> Attribute {
+        isDisabled ? Attribute(name: "disabled", value: nil, ignoreIfValueIsEmpty: false) : .empty
+    }
+
+    /// Assign whether the element should allow the selection of multiple values.
+    /// - parameter isMultiple: Whether multiple values are allowed.
+    static func multiple(_ isMultiple: Bool) -> Attribute {
+        isMultiple ? Attribute(name: "multiple", value: nil, ignoreIfValueIsEmpty: false) : .empty
+    }
 }
 
 public extension Node where Context == HTML.TextAreaContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -301,13 +301,13 @@ public extension Attribute where Context == HTML.InputContext {
     /// Assign whether the element is required before submitting the form.
     /// - parameter isRequired: Whether the element is required.
     static func required(_ isRequired: Bool) -> Attribute {
-        isRequired ? Attribute(name: "required", value: "true") : .empty
+        isRequired ? Attribute(name: "required", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
     
     /// Assign whether the element should be autofocused when the page loads.
     /// - parameter isOn: Whether autofocus should be turned on.
     static func autofocus(_ isOn: Bool) -> Attribute {
-        isOn ? Attribute(name: "autofocus", value: "true") : .empty
+        isOn ? Attribute(name: "autofocus", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
 }
 
@@ -327,13 +327,13 @@ public extension Node where Context == HTML.TextAreaContext {
     /// Assign whether the element is required before submitting the form.
     /// - parameter isRequired: Whether the element is required.
     static func required(_ isRequired: Bool) -> Node {
-        isRequired ? .attribute(named: "required", value: "true") : .empty
+        isRequired ? .attribute(named: "required") : .empty
     }
     
     /// Assign whether the element should be autofocused when the page loads.
     /// - parameter isOn: Whether autofocus should be turned on.
     static func autofocus(_ isOn: Bool) -> Node {
-        isOn ? .attribute(named: "autofocus", value: "true") : .empty
+        isOn ? .attribute(named: "autofocus") : .empty
     }
 }
 

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -386,7 +386,7 @@ final class HTMLComponentTests: XCTestCase {
         .render()
 
         XCTAssertEqual(html, """
-        <iframe src="url.com" frameborder="0" allowfullscreen="true" allow="gyroscope"></iframe>
+        <iframe src="url.com" frameborder="0" allowfullscreen allow="gyroscope"></iframe>
         """)
     }
 

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -364,7 +364,7 @@ final class HTMLComponentTests: XCTestCase {
         <form action="url.com" method="post">\
         <fieldset>\
         <label>Username\
-        <input type="text" name="username" required="true" autofocus="true" autocomplete="off"/>\
+        <input type="text" name="username" required autofocus autocomplete="off"/>\
         </label>\
         <label class="password-label">Password\
         <input type="password" name="password" class="password-input"/>\

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -589,7 +589,7 @@ final class HTMLTests: XCTestCase {
 
         assertEqualHTMLContent(html, """
         <body>\
-        <iframe src="url.com" frameborder="0" allow="gyroscope" allowfullscreen="true"></iframe>\
+        <iframe src="url.com" frameborder="0" allow="gyroscope" allowfullscreen></iframe>\
         </body>
         """)
     }

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -659,11 +659,15 @@ final class HTMLTests: XCTestCase {
 
     func testDetails() {
         let html = HTML(.body(
-            .details(.summary("Summary"), .p("Text"))
+            .details(.open(true), .summary("Open Summary"), .p("Text")),
+            .details(.open(false), .summary("Closed Summary"), .p("Text"))
         ))
 
         assertEqualHTMLContent(html, """
-        <body><details><summary>Summary</summary><p>Text</p></details></body>
+        <body>\
+        <details open><summary>Open Summary</summary><p>Text</p></details>\
+        <details><summary>Closed Summary</summary><p>Text</p></details>\
+        </body>
         """)
     }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -361,6 +361,7 @@ final class HTMLTests: XCTestCase {
                 .textarea(.name("f"), .cols(50), .rows(10), .required(true), .text("Test")),
                 .textarea(.name("g"), .autofocus(true), .placeholder("Placeholder"), .readonly(false), .disabled(false)),
                 .textarea(.name("h"), .readonly(true), .disabled(true), .text("Test")),
+                .input(.name("i"), .type(.checkbox), .checked(true)),
                 .input(.type(.file), .multiple(true)),
                 .input(.type(.submit), .value("Send"))
             )
@@ -379,6 +380,7 @@ final class HTMLTests: XCTestCase {
         <textarea name="f" cols="50" rows="10" required>Test</textarea>\
         <textarea name="g" autofocus placeholder="Placeholder"></textarea>\
         <textarea name="h" readonly disabled>Test</textarea>\
+        <input name="i" type="checkbox" checked/>\
         <input type="file" multiple/>\
         <input type="submit" value="Send"/>\
         </form></body>

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -361,11 +361,11 @@ final class HTMLTests: XCTestCase {
         <label for="a">A label</label>\
         <input name="a" type="text"/>\
         </fieldset>\
-        <input name="b" type="search" autocomplete="off" autofocus="true"/>\
+        <input name="b" type="search" autocomplete="off" autofocus/>\
         <input name="c" type="text"/>\
-        <input name="d" type="email" placeholder="email address" autocomplete="on" required="true"/>\
-        <textarea name="e" cols="50" rows="10" required="true">Test</textarea>\
-        <textarea name="f" autofocus="true"></textarea>\
+        <input name="d" type="email" placeholder="email address" autocomplete="on" required/>\
+        <textarea name="e" cols="50" rows="10" required>Test</textarea>\
+        <textarea name="f" autofocus></textarea>\
         <input type="submit" value="Send"/>\
         </form></body>
         """)

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -190,6 +190,14 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, #"<body class="b"></body>"#)
     }
 
+    func testHiddenElements() {
+        let html = HTML(.body(
+            .div(.hidden(false)),
+            .div(.hidden(true))
+        ))
+        assertEqualHTMLContent(html, "<body><div></div><div hidden></div></body>")
+    }
+
     func testTitleAttribute() {
         let html = HTML(
             .head(

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -593,13 +593,17 @@ final class HTMLTests: XCTestCase {
                 .src("url.com"),
                 .frameborder(false),
                 .allow("gyroscope"),
+                .allowfullscreen(false)
+            ),
+            .iframe(
                 .allowfullscreen(true)
             )
         ))
 
         assertEqualHTMLContent(html, """
         <body>\
-        <iframe src="url.com" frameborder="0" allow="gyroscope" allowfullscreen></iframe>\
+        <iframe src="url.com" frameborder="0" allow="gyroscope"></iframe>\
+        <iframe allowfullscreen></iframe>\
         </body>
         """)
     }

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -351,7 +351,8 @@ final class HTMLTests: XCTestCase {
                 .input(.name("d"), .type(.email), .placeholder("email address"), .autocomplete(true), .required(true)),
                 .input(.name("e"), .type(.text), .readonly(true), .disabled(true)),
                 .textarea(.name("f"), .cols(50), .rows(10), .required(true), .text("Test")),
-                .textarea(.name("g"), .autofocus(true)),
+                .textarea(.name("g"), .autofocus(true), .readonly(false), .disabled(false)),
+                .textarea(.name("h"), .readonly(true), .disabled(true), .text("Test")),
                 .input(.type(.file), .multiple(true)),
                 .input(.type(.submit), .value("Send"))
             )
@@ -369,6 +370,7 @@ final class HTMLTests: XCTestCase {
         <input name="e" type="text" readonly disabled/>\
         <textarea name="f" cols="50" rows="10" required>Test</textarea>\
         <textarea name="g" autofocus></textarea>\
+        <textarea name="h" readonly disabled>Test</textarea>\
         <input type="file" multiple/>\
         <input type="submit" value="Send"/>\
         </form></body>

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -351,7 +351,7 @@ final class HTMLTests: XCTestCase {
                 .input(.name("d"), .type(.email), .placeholder("email address"), .autocomplete(true), .required(true)),
                 .input(.name("e"), .type(.text), .readonly(true), .disabled(true)),
                 .textarea(.name("f"), .cols(50), .rows(10), .required(true), .text("Test")),
-                .textarea(.name("g"), .autofocus(true), .readonly(false), .disabled(false)),
+                .textarea(.name("g"), .autofocus(true), .placeholder("Placeholder"), .readonly(false), .disabled(false)),
                 .textarea(.name("h"), .readonly(true), .disabled(true), .text("Test")),
                 .input(.type(.file), .multiple(true)),
                 .input(.type(.submit), .value("Send"))
@@ -369,7 +369,7 @@ final class HTMLTests: XCTestCase {
         <input name="d" type="email" placeholder="email address" autocomplete="on" required/>\
         <input name="e" type="text" readonly disabled/>\
         <textarea name="f" cols="50" rows="10" required>Test</textarea>\
-        <textarea name="g" autofocus></textarea>\
+        <textarea name="g" autofocus placeholder="Placeholder"></textarea>\
         <textarea name="h" readonly disabled>Test</textarea>\
         <input type="file" multiple/>\
         <input type="submit" value="Send"/>\

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -362,7 +362,7 @@ final class HTMLTests: XCTestCase {
                 .textarea(.name("g"), .autofocus(true), .placeholder("Placeholder"), .readonly(false), .disabled(false)),
                 .textarea(.name("h"), .readonly(true), .disabled(true), .text("Test")),
                 .input(.name("i"), .type(.checkbox), .checked(true)),
-                .input(.type(.file), .multiple(true)),
+                .input(.name("j"), .type(.file), .multiple(true)),
                 .input(.type(.submit), .value("Send"))
             )
         ))
@@ -381,7 +381,7 @@ final class HTMLTests: XCTestCase {
         <textarea name="g" autofocus placeholder="Placeholder"></textarea>\
         <textarea name="h" readonly disabled>Test</textarea>\
         <input name="i" type="checkbox" checked/>\
-        <input type="file" multiple/>\
+        <input name="j" type="file" multiple/>\
         <input type="submit" value="Send"/>\
         </form></body>
         """)

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -347,10 +347,12 @@ final class HTMLTests: XCTestCase {
                     .input(.name("a"), .type(.text))
                 ),
                 .input(.name("b"), .type(.search), .autocomplete(false), .autofocus(true)),
-                .input(.name("c"), .type(.text), .autofocus(false)),
+                .input(.name("c"), .type(.text), .autofocus(false), .readonly(false), .disabled(false)),
                 .input(.name("d"), .type(.email), .placeholder("email address"), .autocomplete(true), .required(true)),
-                .textarea(.name("e"), .cols(50), .rows(10), .required(true), .text("Test")),
-                .textarea(.name("f"), .autofocus(true)),
+                .input(.name("e"), .type(.text), .readonly(true), .disabled(true)),
+                .textarea(.name("f"), .cols(50), .rows(10), .required(true), .text("Test")),
+                .textarea(.name("g"), .autofocus(true)),
+                .input(.type(.file), .multiple(true)),
                 .input(.type(.submit), .value("Send"))
             )
         ))
@@ -364,8 +366,10 @@ final class HTMLTests: XCTestCase {
         <input name="b" type="search" autocomplete="off" autofocus/>\
         <input name="c" type="text"/>\
         <input name="d" type="email" placeholder="email address" autocomplete="on" required/>\
-        <textarea name="e" cols="50" rows="10" required>Test</textarea>\
-        <textarea name="f" autofocus></textarea>\
+        <input name="e" type="text" readonly disabled/>\
+        <textarea name="f" cols="50" rows="10" required>Test</textarea>\
+        <textarea name="g" autofocus></textarea>\
+        <input type="file" multiple/>\
         <input type="submit" value="Send"/>\
         </form></body>
         """)


### PR DESCRIPTION
I'm expecting a bit of a discussion around this one! So, here's my justification. The [HTML spec](https://html.spec.whatwg.org/) has this to say about [boolean attributes](https://html.spec.whatwg.org/#boolean-attributes):

> A number of attributes are boolean attributes. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value.

It then gives an example of rendering them as this:

```html
<label><input type=checkbox checked name=cheese disabled> Cheese</label>
```

It does then go to say that they are also valid with values, or with empty values, but this functionality can be misleading. For example, all of these `<div>` elements will be rendered hidden:

```html
<div hidden></div>
<div hidden=""></div>
<div hidden="true"></div>
<div hidden="false"></div>
<div hidden="notevenalittlebit"></div>
```

So, this is my case for rendering boolean attributes with the first form. Are you with me? 😬

---

This PR changes the rendering of all existing boolean attributes and adds several that were missing. The attributes I've changed are all defined in the spec as "boolean attributes":

* "[The required attribute is a boolean attribute](https://html.spec.whatwg.org/#the-required-attribute)"
* "[The autofocus attribute is a boolean attribute](https://html.spec.whatwg.org/#the-autofocus-attribute)"
* "[The readonly attribute is a boolean attribute](https://html.spec.whatwg.org/#the-readonly-attribute)"
* "[The disabled content attribute is a boolean attribute](https://html.spec.whatwg.org/#enabling-and-disabling-form-controls:-the-disabled-attribute)"
* "[The multiple attribute is a boolean attribute](https://html.spec.whatwg.org/#the-multiple-attribute)"
* "[The allowfullscreen attribute is a boolean attribute](https://html.spec.whatwg.org/#the-iframe-element)"
* "[The open content attribute is a boolean attribute](https://html.spec.whatwg.org/#the-details-element)"
* "[The hidden attribute is a boolean attribute](https://html.spec.whatwg.org/#the-hidden-attribute)"

I also added a `placeholder` attribute to `textarea` in this as I noticed it was missing while making these changes. I know that should probably be a separate PR, but the test code is tricky to merge as two separate PRs.

One thing that's missing from this is adding this to components, but I didn't want to do that before knowing if you'd accept it!