### PR TITLE
Added a global `spellcheck` attribute and tests with common use cases

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -29,7 +29,7 @@ public extension Attribute where Context: HTMLContext {
     }
 
     /// Assign whether operating system level spell checking should be enabled.
-    /// - parameter isEnabled: Whether spell checking should be enabled..
+    /// - parameter isEnabled: Whether spell checking should be enabled.
     static func spellcheck(_ isEnabled: Bool) -> Attribute {
         Attribute(name: "spellcheck", value: String(isEnabled))
     }
@@ -58,7 +58,7 @@ public extension Node where Context: HTMLContext {
     }
 
     /// Assign whether operating system level spell checking should be enabled.
-    /// - parameter isEnabled: Whether spell checking should be enabled..
+    /// - parameter isEnabled: Whether spell checking should be enabled.
     static func spellcheck(_ isEnabled: Bool) -> Node {
         .attribute(named: "spellcheck", value: String(isEnabled))
     }

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -27,6 +27,12 @@ public extension Attribute where Context: HTMLContext {
     static func data(named name: String, value: String) -> Attribute {
         Attribute(name: "data-\(name)", value: value)
     }
+
+    /// Assign whether operating system level spell checking should be enabled.
+    /// - parameter isEnabled: Whether spell checking should be enabled..
+    static func spellcheck(_ isEnabled: Bool) -> Attribute {
+        Attribute(name: "spellcheck", value: String(isEnabled))
+    }
 }
 
 public extension Node where Context: HTMLContext {
@@ -49,6 +55,12 @@ public extension Node where Context: HTMLContext {
     /// - parameter value: The attribute's string value.
     static func data(named name: String, value: String) -> Node {
         .attribute(named: "data-\(name)", value: value)
+    }
+
+    /// Assign whether operating system level spell checking should be enabled.
+    /// - parameter isEnabled: Whether spell checking should be enabled..
+    static func spellcheck(_ isEnabled: Bool) -> Node {
+        .attribute(named: "spellcheck", value: String(isEnabled))
     }
 }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -723,6 +723,26 @@ final class HTMLTests: XCTestCase {
         <body data-user-name="John"><img data-icon="User"/></body>
         """)
     }
+
+    func testSpellcheckAttribute() {
+        let html = HTML(
+            .body(
+                .spellcheck(true),
+                .form(
+                    .input(.type(.text), .spellcheck(false)),
+                    .textarea(.spellcheck(false))
+                )
+            )
+        )
+        assertEqualHTMLContent(html, """
+            <body spellcheck="true">\
+            <form>\
+            <input type="text" spellcheck="false"/>\
+            <textarea spellcheck="false"></textarea>\
+            </form>\
+            </body>
+            """)
+    }
     
     func testSubresourceIntegrity() {
         let html = HTML(.head(


### PR DESCRIPTION
It may feel like `spellcheck` should be specific to `form` or `input` elements, but it's global. Probably because of `contenteditable`, which Plot doesn't support yet, but I'm sure it will some day.

For proof, see [this section](https://html.spec.whatwg.org/#global-attributes) of the spec.