### PR TITLE
Made the `title` attribute into a global attribute.

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -27,6 +27,12 @@ public extension Attribute where Context: HTMLContext {
     static func data(named name: String, value: String) -> Attribute {
         Attribute(name: "data-\(name)", value: value)
     }
+
+    /// Specify a title for the element.
+    /// - parameter title: The title to assign to the element.
+    static func title(_ title: String) -> Attribute {
+        Attribute(name: "title", value: title)
+    }
 }
 
 public extension Node where Context: HTMLContext {
@@ -49,6 +55,12 @@ public extension Node where Context: HTMLContext {
     /// - parameter value: The attribute's string value.
     static func data(named name: String, value: String) -> Node {
         .attribute(named: "data-\(name)", value: value)
+    }
+
+    /// Specify a title for the element.
+    /// - parameter title: The title to assign to the element.
+    static func title(_ title: String) -> Node {
+        .attribute(named: "title", value: title)
     }
 }
 
@@ -99,16 +111,6 @@ public extension Node where Context == HTML.DocumentContext {
     /// - parameter language: The language to specify.
     static func lang(_ language: Language) -> Node {
         .attribute(named: "lang", value: language.rawValue)
-    }
-}
-
-// MARK: - Body
-
-public extension Node where Context: HTML.BodyContext {
-    /// Specify a title for the element.
-    /// - parameter title: The title to assign to the element.
-    static func title(_ title: String) -> Node {
-        .attribute(named: "title", value: title)
     }
 }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -191,14 +191,26 @@ final class HTMLTests: XCTestCase {
     }
 
     func testTitleAttribute() {
-        let html = HTML(.body(
-            .div(.title("Division title"),
-                .p(.title("Paragraph title"), "Paragraph"),
-                .a(.href("#"), .title("Link title"), "Link")
+        let html = HTML(
+            .head(
+                .link(
+                    .rel(.alternate),
+                    .title("Alternative representation")
+                )
+            ),
+            .body(
+                .div(
+                    .title("Division title"),
+                    .p(.title("Paragraph title"), "Paragraph"),
+                    .a(.href("#"), .title("Link title"), "Link")
+                )
             )
-        ))
+        )
         
         assertEqualHTMLContent(html, """
+        <head>\
+        <link rel="alternate" title="Alternative representation"/>\
+        </head>\
         <body>\
         <div title="Division title">\
         <p title="Paragraph title">Paragraph</p>\


### PR DESCRIPTION
The [title attribute](https://html.spec.whatwg.org/#the-title-attribute) is listed under [Global attributes](https://html.spec.whatwg.org/#global-attributes) and is useful in the `head`, for example for `link` elements.