### PR TITLE
Add the dir HTML attribute

### DIFF
--- a/Sources/Plot/API/ComponentAttributes.swift
+++ b/Sources/Plot/API/ComponentAttributes.swift
@@ -40,6 +40,12 @@ public extension Component {
         attribute(named: "id", value: id)
     }
 
+    /// Assign a directionality to this component's element.
+    /// - parameter directionality: The directionality to assign.
+    func dir(_ directionality: Directionality) -> Component {
+        attribute(named: "dir", value: directionality.rawValue)
+    }
+
     /// Assign whether this component hierarchy's `Input` components should have
     /// autocomplete turned on or off. This value is placed in the environment, and
     /// is thus inherited by all child components. Note that this modifier only

--- a/Sources/Plot/API/ComponentAttributes.swift
+++ b/Sources/Plot/API/ComponentAttributes.swift
@@ -42,7 +42,7 @@ public extension Component {
 
     /// Assign a directionality to this component's element.
     /// - parameter directionality: The directionality to assign.
-    func dir(_ directionality: Directionality) -> Component {
+    func directionality(_ directionality: Directionality) -> Component {
         attribute(named: "dir", value: directionality.rawValue)
     }
 

--- a/Sources/Plot/API/Directionality.swift
+++ b/Sources/Plot/API/Directionality.swift
@@ -1,0 +1,12 @@
+/**
+ *  Plot
+ *  Copyright (c) John Sundell 2021
+ *  MIT license, see LICENSE file for details
+ */
+
+/// Enum defining an element's text directionality.
+public enum Directionality: String {
+    case leftToRight = "ltr"
+    case rightToLeft = "rtl"
+    case auto = "auto"
+}

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -39,6 +39,12 @@ public extension Attribute where Context: HTMLContext {
     static func title(_ title: String) -> Attribute {
         Attribute(name: "title", value: title)
     }
+
+    /// Specify a directionality for the element.
+    /// - parameter directionality: The directionality to assign to the element.
+    static func dir(_ directionality: Directionality) -> Attribute {
+        Attribute(name: "dir", value: directionality.rawValue)
+    }
 }
 
 public extension Node where Context: HTMLContext {
@@ -79,6 +85,12 @@ public extension Node where Context: HTMLContext {
     /// - parameter isHidden: Whether the element should be hidden or not.
     static func hidden(_ isHidden: Bool) -> Node {
         isHidden ? .attribute(named: "hidden") : .empty
+    }
+
+    /// Specify a directionality for the element.
+    /// - parameter directionality: The directionality to assign to the element.
+    static func dir(_ directionality: Directionality) -> Node {
+        .attribute(named: "dir", value: directionality.rawValue)
     }
 }
 

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -78,6 +78,14 @@ final class HTMLComponentTests: XCTestCase {
         """)
     }
 
+    func testAssigningDirectionalityToElement() {
+        let html = Paragraph("Hello")
+            .dir(.leftToRight)
+            .render()
+
+        XCTAssertEqual(html, #"<p dir="ltr">Hello</p>"#)
+    }
+
     func testAppendingClasses() {
         let html = Paragraph("Hello")
             .class("one")

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -80,7 +80,7 @@ final class HTMLComponentTests: XCTestCase {
 
     func testAssigningDirectionalityToElement() {
         let html = Paragraph("Hello")
-            .dir(.leftToRight)
+            .directionality(.leftToRight)
             .render()
 
         XCTAssertEqual(html, #"<p dir="ltr">Hello</p>"#)

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -17,6 +17,21 @@ final class HTMLTests: XCTestCase {
         XCTAssertEqual(html.render(), #"<!DOCTYPE html><html lang="en"></html>"#)
     }
 
+    func testPageDirectionalityLeftToRight() {
+        let html = HTML(.dir(.leftToRight))
+        XCTAssertEqual(html.render(), #"<!DOCTYPE html><html dir="ltr"></html>"#)
+    }
+
+    func testPageDirectionalityRightToLeft() {
+        let html = HTML(.dir(.rightToLeft))
+        XCTAssertEqual(html.render(), #"<!DOCTYPE html><html dir="rtl"></html>"#)
+    }
+
+    func testPageDirectionalityAuto() {
+        let html = HTML(.dir(.auto))
+        XCTAssertEqual(html.render(), #"<!DOCTYPE html><html dir="auto"></html>"#)
+    }
+
     func testHeadAndBody() {
         let html = HTML(.head(), .body())
         assertEqualHTMLContent(html, "<head></head><body></body>")
@@ -247,6 +262,46 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, """
         <body><dl><dt>Term</dt><dd>Description</dd></dl></body>
         """)
+    }
+
+    func testTextDirectionalityLeftToRight() {
+        let html = HTML(.body(
+            .h1(.dir(.leftToRight), "Text")
+        ))
+
+        assertEqualHTMLContent(html, #"<body><h1 dir="ltr">Text</h1></body>"#)
+    }
+
+    func testTextDirectionalityRightToLeft() {
+        let html = HTML(.body(
+            .h1(.dir(.rightToLeft), "Text")
+        ))
+
+        assertEqualHTMLContent(html, #"<body><h1 dir="rtl">Text</h1></body>"#)
+    }
+
+    func testTextDirectionalityAuto() {
+        let html = HTML(.body(
+            .h1(.dir(.auto), "Text")
+        ))
+
+        assertEqualHTMLContent(html, #"<body><h1 dir="auto">Text</h1></body>"#)
+    }
+
+    func testInputDirectionalityAuto() {
+        let html = HTML(.body(
+            .input(.dir(.auto))
+        ))
+
+        assertEqualHTMLContent(html, #"<body><input dir="auto"/></body>"#)
+    }
+
+    func testTextAreaDirectionalityLeftToRight() {
+        let html = HTML(.body(
+            .textarea(.dir(.auto))
+        ))
+
+        assertEqualHTMLContent(html, #"<body><textarea dir="auto"></textarea></body>"#)
     }
 
     func testAnchors() throws {


### PR DESCRIPTION
Since I will be using this package to build my personal website, which will be supporting English and Arabic, I figured the best way to thank you was to add this small contribution.

I added the ability to add [the `dir` attribute](https://html.spec.whatwg.org/#the-dir-attribute) in both the `Node` and `Component` based APIs.

It is a global attribute that can be added to any HTML elemnt (technically any element including non-HTML, but I didn't focuse on XML in this PR).

I added a new enum called `Directionality` (the name is inspired from the spec linked above) to hold the three possible values. I made the case names clearer to read and added the actual HTML values as a raw value to each case.

```swift
public enum Directionality: String {
    case leftToRight = "ltr"
    case rightToLeft = "rtl"
    case auto = "auto"
}
```

users can use this like so:
```swift
// Support Arabic for the entire document.
let html = HTML(
    .lang(.arabic),
    .dir(.rightToLeft),
    .body(.component(Home())
)

// Or for a specific element.
struct Home: Component {
    var body: Component {
        H1("أهلًا بالعالم!").dir(.auto)
    }
}
```

I hope I added them to the correct extensions.

Your discussions and comments are always welcome.