### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Plot is distributed using the [Swift Package Manager](https://swift.org/package-
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/johnsundell/plot.git", from: "0.9.0")
+        .package(url: "https://github.com/JohnSundell/Plot.git", from: "0.10.0")
     ],
     ...
 )


### PR DESCRIPTION
Swift Package manager required the upper case `P` in Plot to be able to resolve the dependencies.

```
dependencies: [
        .package(url: "https://github.com/johnsundell/plot.git", from: "0.10.0") //Didn't work with a lowercase P.
    ],
targets: [
        .target(
            name: "MyCoolLib",
            dependencies: [
                .product(name: "Plot", package: "Plot")
            ]
        )
    ]
```