### PR TITLE
Update README.md to mark a codeblock as being `swift`

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ let string = header.render()
 
 Just like nodes, components can also be rendered on their own:
 
-```
+```swift
 let header = Header {
     H1("Title")
     Span("Description")


### PR DESCRIPTION
Added a missing `swift` in codeblock to make things slightly easier to read.