### PR TITLE
Adding `type` attribute to PictureSourceContext

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -255,6 +255,12 @@ public extension Attribute where Context == HTML.PictureSourceContext {
     static func media(_ query: String) -> Attribute {
         Attribute(name: "media", value: query)
     }
+
+    /// Assign a string describing the MIME type, using the `type` attribute.
+    /// - parameter type: The type (MIME type) for this element.
+    static func type(_ type: String) -> Attribute {
+        Attribute(name: "type", value: type)
+    }
 }
 
 // MARK: - Forms, input and options


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture#the_type_attribute