### PR TITLE
Fix compiler error and warning introduced in Swift 5.6

### DIFF
--- a/Sources/Plot/API/EnvironmentKey.swift
+++ b/Sources/Plot/API/EnvironmentKey.swift
@@ -39,11 +39,11 @@ public extension EnvironmentKey {
     }
 }
 
-public extension EnvironmentKey where Value: ExpressibleByNilLiteral {
+public extension EnvironmentKey {
     /// Initialize a key with an explicit identifier.
     /// - parameter identifier: The identifier that the key should have. Must
     ///   be a static string that's defined using a compile time literal.
-    init(identifier: StaticString) {
+    init<T>(identifier: StaticString) where Value == T? {
         self.init(identifier: identifier, defaultValue: nil)
     }
 
@@ -51,7 +51,7 @@ public extension EnvironmentKey where Value: ExpressibleByNilLiteral {
     /// be computed based on the name of the property or function that created it.
     /// - parameter autoIdentifier: This parameter will be filled in by the
     ///   compiler based on the name of the call site's enclosing function/property.
-    init(autoIdentifier: StaticString = #function) {
+    init<T>(autoIdentifier: StaticString = #function) where Value == T? {
         self.init(identifier: autoIdentifier, defaultValue: nil)
     }
 }

--- a/Sources/Plot/API/HTMLAnchorTarget.swift
+++ b/Sources/Plot/API/HTMLAnchorTarget.swift
@@ -10,11 +10,16 @@ import Foundation
 /// attribute, which specifies how its URL should be opened.
 public enum HTMLAnchorTarget: String {
     /// The URL should be opened in the current browser context (default).
-    case `self` = "self"
+    case current = "self"
     /// The URL should be opened in a new, blank tab or window.
     case blank = "_blank"
     /// The URL should be opened in any parent frame.
     case parent = "_parent"
     /// The URL should be opened in the topmost frame.
     case top = "_top"
+}
+
+extension HTMLAnchorTarget {
+    @available(*, deprecated, message: "Use .current instead")
+    static var `self`: Self { current }
 }


### PR DESCRIPTION
- Replace `HTMLAnchorTarget.self` with `.current` (while still maintaining backward compatibility with `.self` using a deprecated computed property).
- Use per-`init` generic type constraints for optional `EnvironmentKey.Value` types rather than applying an extension-wide constraint using `ExpressibleByNilLiteral`.