### PR TITLE
Update HTMLAnchorTarget.swift

### DIFF
--- a/Sources/Plot/API/HTMLAnchorTarget.swift
+++ b/Sources/Plot/API/HTMLAnchorTarget.swift
@@ -10,7 +10,7 @@ import Foundation
 /// attribute, which specifies how its URL should be opened.
 public enum HTMLAnchorTarget: String {
     /// The URL should be opened in the current browser context (default).
-    case current = "self"
+    case current = "_self"
     /// The URL should be opened in a new, blank tab or window.
     case blank = "_blank"
     /// The URL should be opened in any parent frame.


### PR DESCRIPTION
Though not often used, the `target="self"` attribute is incorrect, and should have the prefix of an underscore `_`.

HTML spec guide: https://html.spec.whatwg.org/#browsing-context-names

Proposal of change would allow use of the `.current` to open in the same page