### PR TITLE
Add languages.

### DIFF
--- a/Sources/Plot/API/Language.swift
+++ b/Sources/Plot/API/Language.swift
@@ -41,6 +41,8 @@ public enum Language: String {
     case chechen = "ce"
     case chichewa, chewa, nyanja = "ny"
     case chinese = "zh"
+    case traditionalChinese = "zh-Hant"
+    case simplifiedChinese = "zh-Hans"
     case chuvash = "cv"
     case cornish = "kw"
     case corsican = "co"


### PR DESCRIPTION
Many of the same characters look different in traditional Chinese and simplified Chinese, so it is necessary to specify which Chinese they are.