### PR TITLE
Add twitter:site meta tag nodes

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -138,6 +138,8 @@ public extension HTML {
     enum TableContext: HTMLStylableContext {}
     /// The context within an HTML `<tr>` element.
     enum TableRowContext: HTMLStylableContext {}
+    /// The context within an HTML `<time>` element.
+    enum TimeContext: HTMLDateTimeContext {}
     /// The context within an HTML `<video>` element.
     enum VideoContext: HTMLMediaContext {
         public typealias SourceContext = VideoSourceContext
@@ -148,6 +150,9 @@ public extension HTML {
 
 /// Context shared among all HTML elements.
 public protocol HTMLContext {}
+/// Context shared among all HTML elements that support the `datetime`
+/// attribute, such as `<time>`.
+public protocol HTMLDateTimeContext: HTMLContext {}
 /// Context shared among all HTML elements that can have their dimensions
 /// (width and height) specified through attributes, such as `<video>`.
 public protocol HTMLDimensionContext: HTMLContext {}

--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -139,7 +139,7 @@ public extension HTML {
     /// The context within an HTML `<tr>` element.
     enum TableRowContext: HTMLStylableContext {}
     /// The context within an HTML `<time>` element.
-    enum TimeContext: HTMLDateTimeContext {}
+    final class TimeContext: BodyContext, HTMLDateTimeContext {}
     /// The context within an HTML `<video>` element.
     enum VideoContext: HTMLMediaContext {
         public typealias SourceContext = VideoSourceContext

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -1,3 +1,4 @@
+import Foundation
 /**
 *  Plot
 *  Copyright (c) John Sundell 2019
@@ -188,6 +189,13 @@ public extension Node where Context == HTML.AnchorContext {
     ///   `HTMLAnchorRelationship` for more info.
     static func rel(_ relationship: HTMLAnchorRelationship) -> Node {
         .attribute(named: "rel", value: relationship.rawValue)
+    }
+}
+
+// MARK: - DateTime
+public extension Node where Context == HTML.TimeContext {
+    static func datetime(_ datetime: Date) -> Node {
+        .attribute(named: "datetime", value: DateFormatter.ISOstring(from: datetime))
     }
 }
 

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -499,7 +499,9 @@ public struct Label: Component {
 /// Component used to render a link/anchor using an `<a>` element.
 public struct Link: Component {
     /// The URL that the link should point to.
-    public var url: URLRepresentable
+    public var url: URLRepresentable?
+    /// The ID of the link.
+    public var id: String?
     /// A closure that provides the components that should make up the link's label.
     @ComponentBuilder public var label: ContentProvider
 
@@ -527,10 +529,19 @@ public struct Link: Component {
             Node<HTML.BodyContext>.text(label)
         }
     }
+    
+    /// Create a new link instance.
+    /// - parameters:
+    ///   - id: The link's ID to enable intra-page linking
+    public init(_ id: String) {
+        self.id = id
+        self.label = { ComponentGroup() }
+    }
 
     public var body: Component {
         Node.a(
-            .href(url),
+            .unwrap(url, Node.href),
+            .unwrap(id, Node.id),
             .unwrap(relationship, Node.rel),
             .unwrap(target, Node.target),
             .component(label())

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -4,6 +4,8 @@
 *  MIT license, see LICENSE file for details
 */
 
+import Foundation
+
 // MARK: - Nodes
 
 public extension Node where Context == HTML.HeadContext {
@@ -864,6 +866,27 @@ public struct TextArea: InputComponent {
             .unwrap(numberOfColumns, Node.cols),
             .required(isRequired),
             .unwrap(isAutoFocused, Node.autofocus)
+        )
+    }
+}
+
+/// Component that represents a datetime instance
+public struct Time: Component {
+    /// A closure that provides the components that the row should contain.
+    @ComponentBuilder public var content: ContentProvider
+    /// The datetime that the element represents
+    public var datetime: Date?
+    
+    public init(datetime: Date? = nil,
+                @ComponentBuilder content: @escaping ContentProvider) {
+        self.datetime = datetime
+        self.content = content
+    }
+    
+    public var body: Component {
+        Node.time(
+            .unwrap(datetime, Node.datetime),
+            .component(content())
         )
     }
 }

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -81,6 +81,12 @@ public extension Node where Context == HTML.HeadContext {
     static func twitterCardType(_ type: TwitterCardType) -> Node {
         .meta(.name("twitter:card"), .content(type.rawValue))
     }
+    
+    /// Declare the Twitter handle of the site that Twitter should use when displaying a link
+    /// - parameter handle: The handle of the account on Twitter. For example: `@SwiftBySundell`
+    static func twitterUsername(_ username: String) -> Node {
+        .meta(.name("twitter:site"), .content(username))
+    }
 
     /// Declare how the page should behave in terms of viewport responsiveness.
     /// This declaration is important when building HTML pages for display on

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -1,3 +1,4 @@
+import Foundation
 /**
 *  Plot
 *  Copyright (c) John Sundell 2019
@@ -381,6 +382,13 @@ public extension Node where Context: HTML.BodyContext {
     /// - parameter nodes: The element's attributes and nodes.
     static func textarea(_ nodes: Node<HTML.TextAreaContext>...) -> Node {
         .element(named: "textarea", nodes: nodes)
+    }
+    
+    /// Add a `<time>` HTML element within the current context.
+    /// - parameter datetime: The datetime that the element represents
+    /// - parameter nodes: The element's attributes and nodes.
+    static func time(_ nodes: Node<HTML.TimeContext>...) -> Node {
+        .element(named: "time", nodes: nodes)
     }
 
     /// Add a `<u>` HTML element within the current context.

--- a/Sources/Plot/Internal/DateFormatter+string.swift
+++ b/Sources/Plot/Internal/DateFormatter+string.swift
@@ -1,0 +1,26 @@
+//
+//  DateFormatter+string.swift
+//  
+//
+//  Created by Harry Day on 24/08/2022
+//  
+//
+//  Twitter: https://twitter.com/harrydayexe
+//  Github: https://github.com/harrydayexe
+//
+    
+
+import Foundation
+
+internal extension DateFormatter {
+    /// Convert a date object into a RF361 compliant datetime string.
+    /// - parameter date: The date object to convert to a string.
+    static func ISOstring(from date: Date) -> String {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        
+        return df.string(from: date)
+    }
+}

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -418,6 +418,12 @@ final class HTMLComponentTests: XCTestCase {
         </div>
         """)
     }
+    
+    func testAnchorLink() {
+        let html = Link("testID").render()
+        
+        XCTAssertEqual(html, #"<a id="testID"></a>"#)
+    }
 
     func testOrderedList() {
         let html = List(["One", "Two"])

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -432,6 +432,14 @@ final class HTMLComponentTests: XCTestCase {
 
         XCTAssertEqual(html, "<ol><li>One</li><li>Two</li></ol>")
     }
+    
+    func testTime() {
+        let html = Time(datetime: Date(timeIntervalSince1970: 1321628079)) {
+            Paragraph("Hello World")
+        }.render()
+        
+        XCTAssertEqual(html, #"<time datetime="2011-11-18T14:54:39Z"><p>Hello World</p></time>"#)
+    }
 
     func testOrderedListWithExplicitItems() {
         struct SeventhComponent: Component {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -88,7 +88,8 @@ final class HTMLTests: XCTestCase {
     func testSocialImageMetadata() {
         let html = HTML(.head(
             .socialImageLink("url.png"),
-            .twitterCardType(.summaryLargeImage)
+            .twitterCardType(.summaryLargeImage),
+            .twitterUsername("@CreatorHandle")
         ))
 
         assertEqualHTMLContent(html, """
@@ -96,6 +97,7 @@ final class HTMLTests: XCTestCase {
         <meta name="twitter:image" content="url.png"/>\
         <meta name="og:image" content="url.png"/>\
         <meta name="twitter:card" content="summary_large_image"/>\
+        <meta name="twitter:site" content="@CreatorHandle"/>\
         </head>
         """)
     }

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -822,6 +822,19 @@ final class HTMLTests: XCTestCase {
         </picture></body>
         """)
     }
+    
+    func testTime() {
+        let html = HTML(.body(.time(
+            .text("Hello World!"),
+            .datetime(Date(timeIntervalSince1970: 1321628079))
+        )))
+        
+        assertEqualHTMLContent(html, """
+        <body><time datetime="2011-11-18T14:54:39Z">\
+        Hello World!\
+        </time></body>
+        """)
+    }
 
     func testOnClick() {
         let html = HTML(


### PR DESCRIPTION
Hi all,
This change is quite simple but something that is quite nice to have. 

The tag twitter:site is used to identify the site by it's Twitter handle (for example the @ SwiftBySundell twitter account) when shown in a card. See the (documentation)[https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup]

I added a new node `.twitterUsername(_)` to set the Twitter username to be associated with the page.
<meta name="twitter:site" content="@SiteHandle"/>