### PR TITLE
Add crossorigin link attribute

### DIFF
--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -180,8 +180,8 @@ public extension Attribute where Context == HTML.LinkContext {
     }
 
     /// Assign a `crossorigin` attribute to the link.
-    static func crossorigin() -> Attribute {
-        Attribute(name: "crossorigin", value: nil, ignoreIfValueIsEmpty: false)
+    static func crossorigin(_ crossOrigin: Bool) -> Attribute {
+        crossOrigin ? Attribute(name: "crossorigin", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
 }
 

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -178,6 +178,11 @@ public extension Attribute where Context == HTML.LinkContext {
     static func color(_ color: String) -> Attribute {
         Attribute(name: "color", value: color)
     }
+
+    /// Assign a `crossorigin` attribute to the link.
+    static func crossorigin() -> Attribute {
+        Attribute(name: "crossorigin", value: nil, ignoreIfValueIsEmpty: false)
+    }
 }
 
 public extension Attribute where Context: HTMLLinkableContext {

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -179,9 +179,10 @@ public extension Attribute where Context == HTML.LinkContext {
         Attribute(name: "color", value: color)
     }
 
-    /// Assign a `crossorigin` attribute to the link.
-    static func crossorigin(_ crossOrigin: Bool) -> Attribute {
-        crossOrigin ? Attribute(name: "crossorigin", value: nil, ignoreIfValueIsEmpty: false) : .empty
+    /// Assign whether the link should have the crossorigin attribute.
+    /// - parameter isEnabled: Whether crossorigin should be enabled.
+    static func crossorigin(_ isEnabled: Bool) -> Attribute {
+        isEnabled ? Attribute(name: "crossorigin", value: nil, ignoreIfValueIsEmpty: false) : .empty
     }
 }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -174,6 +174,18 @@ final class HTMLTests: XCTestCase {
         """)
     }
 
+    func testCrossoriginLink() {
+        let html = HTML(.head(.link(
+            .rel(.preconnect),
+            .href("https://foo.com"),
+            .crossorigin()
+        )))
+
+        assertEqualHTMLContent(html, """
+        <head><link rel="preconnect" href="https://foo.com" crossorigin/></head>
+        """)
+    }
+
     func testManifestLink() {
         let html = HTML(.head(.link(
             .rel(.manifest),

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -174,15 +174,27 @@ final class HTMLTests: XCTestCase {
         """)
     }
 
-    func testCrossoriginLink() {
+    func testCrossoriginLinkEnabled() {
         let html = HTML(.head(.link(
             .rel(.preconnect),
             .href("https://foo.com"),
-            .crossorigin()
+            .crossorigin(true)
         )))
 
         assertEqualHTMLContent(html, """
         <head><link rel="preconnect" href="https://foo.com" crossorigin/></head>
+        """)
+    }
+
+    func testCrossoriginLinkDisabled() {
+        let html = HTML(.head(.link(
+            .rel(.preconnect),
+            .href("https://foo.com"),
+            .crossorigin(false)
+        )))
+
+        assertEqualHTMLContent(html, """
+        <head><link rel="preconnect" href="https://foo.com"/></head>
         """)
     }
 


### PR DESCRIPTION
The crossorigin attribute is needed for things like Google fonts where you should link to it like below:

```
…
<link rel=“preconnect” href=“http://foo.com” crossorigin />
…
```

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attributes

At the moment doing this means manually creating an `Attribute` instance but this would be cleaner.
