### PR TITLE
Compatibility with Open Graph protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Looking at the above, it may at first seem like Plot simply maps each function c
     <head>
         <title>My website</title>
         <meta name="twitter:title" content="My website"/>
-        <meta name="og:title" content="My website"/>
+        <meta property="og:title" content="My website"/>
         <link rel="stylesheet" href="styles.css" type="text/css"/>
     </head>
     <body>

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -106,14 +106,6 @@ public extension Attribute where Context == HTML.MetaContext {
     }
 }
 
-public extension Node where Context: HTMLNamableContext {
-    /// Assign a property to the element.
-    /// - parameter property: The property to assign.
-    static func property(_ property: String) -> Node {
-        .attribute(named: "property", value: property)
-    }
-}
-
 public extension Attribute where Context: HTMLTypeContext {
     /// Assign a type string to this element.
     /// - parameter type: The name of the type to assign.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -98,6 +98,22 @@ public extension Node where Context: HTMLNamableContext {
     }
 }
 
+public extension Attribute where Context: HTMLNamableContext {
+    /// Assign a property to the element.
+    /// - parameter property: The property to assign.
+    static func property(_ property: String) -> Attribute {
+        Attribute(name: "property", value: property)
+    }
+}
+
+public extension Node where Context: HTMLNamableContext {
+    /// Assign a property to the element.
+    /// - parameter property: The property to assign.
+    static func property(_ property: String) -> Node {
+        .attribute(named: "property", value: property)
+    }
+}
+
 public extension Attribute where Context: HTMLTypeContext {
     /// Assign a type string to this element.
     /// - parameter type: The name of the type to assign.

--- a/Sources/Plot/API/HTMLAttributes.swift
+++ b/Sources/Plot/API/HTMLAttributes.swift
@@ -98,7 +98,7 @@ public extension Node where Context: HTMLNamableContext {
     }
 }
 
-public extension Attribute where Context: HTMLNamableContext {
+public extension Attribute where Context == HTML.MetaContext {
     /// Assign a property to the element.
     /// - parameter property: The property to assign.
     static func property(_ property: String) -> Attribute {

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -33,14 +33,14 @@ public extension Node where Context == HTML.HeadContext {
         return .group([
             .link(.rel(.canonical), .href(url)),
             .meta(.name("twitter:url"), .content(url)),
-            .meta(.name("og:url"), .content(url))
+            .meta(.property("og:url"), .content(url))
         ])
     }
 
     /// Declare the name of the site that this HTML page belongs to.
     /// - parameter name: The name to declare.
     static func siteName(_ name: String) -> Node {
-        .meta(.name("og:site_name"), .content(name))
+        .meta(.property("og:site_name"), .content(name))
     }
 
     /// Declare the HTML page's title, both for browsers and for social sharing.
@@ -49,7 +49,7 @@ public extension Node where Context == HTML.HeadContext {
         .group([
             .element(named: "title", text: title),
             .meta(.name("twitter:title"), .content(title)),
-            .meta(.name("og:title"), .content(title))
+            .meta(.property("og:title"), .content(title))
         ])
     }
 
@@ -59,7 +59,7 @@ public extension Node where Context == HTML.HeadContext {
         .group([
             .meta(.name("description"), .content(text)),
             .meta(.name("twitter:description"), .content(text)),
-            .meta(.name("og:description"), .content(text))
+            .meta(.property("og:description"), .content(text))
         ])
     }
 
@@ -71,7 +71,7 @@ public extension Node where Context == HTML.HeadContext {
 
         return .group([
             .meta(.name("twitter:image"), .content(url)),
-            .meta(.name("og:image"), .content(url))
+            .meta(.property("og:image"), .content(url))
         ])
     }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -48,7 +48,7 @@ final class HTMLTests: XCTestCase {
     func testSiteName() {
         let html = HTML(.head(.siteName("MySite")))
         assertEqualHTMLContent(html, """
-        <head><meta name="og:site_name" content="MySite"/></head>
+        <head><meta property="og:site_name" content="MySite"/></head>
         """)
     }
 
@@ -58,7 +58,7 @@ final class HTMLTests: XCTestCase {
         <head>\
         <link rel="canonical" href="url.com"/>\
         <meta name="twitter:url" content="url.com"/>\
-        <meta name="og:url" content="url.com"/>\
+        <meta property="og:url" content="url.com"/>\
         </head>
         """)
     }
@@ -69,7 +69,7 @@ final class HTMLTests: XCTestCase {
         <head>\
         <title>Title</title>\
         <meta name="twitter:title" content="Title"/>\
-        <meta name="og:title" content="Title"/>\
+        <meta property="og:title" content="Title"/>\
         </head>
         """)
     }
@@ -80,7 +80,7 @@ final class HTMLTests: XCTestCase {
         <head>\
         <meta name="description" content="Description"/>\
         <meta name="twitter:description" content="Description"/>\
-        <meta name="og:description" content="Description"/>\
+        <meta property="og:description" content="Description"/>\
         </head>
         """)
     }
@@ -94,7 +94,7 @@ final class HTMLTests: XCTestCase {
         assertEqualHTMLContent(html, """
         <head>\
         <meta name="twitter:image" content="url.png"/>\
-        <meta name="og:image" content="url.png"/>\
+        <meta property="og:image" content="url.png"/>\
         <meta name="twitter:card" content="summary_large_image"/>\
         </head>
         """)


### PR DESCRIPTION
Based on [official site](https://ogp.me)
All meta attributes with og:... content should use "property" name