### PR TITLE
Extend dl with div wrapped groups

### DIFF
--- a/Sources/Plot/API/HTML.swift
+++ b/Sources/Plot/API/HTML.swift
@@ -83,7 +83,7 @@ public extension HTML {
     /// The context within an HTML document's `<head>` element.
     enum HeadContext: HTMLContext, HTMLScriptableContext {}
     /// The context within an HTML document's `<body>` element.
-    class BodyContext: HTMLStylableContext, HTMLScriptableContext, HTMLImageContainerContext {}
+    class BodyContext: HTMLStylableContext, HTMLScriptableContext, HTMLImageContainerContext, HTMLDividableContext {}
     /// The context within an HTML `<a>` element.
     final class AnchorContext: BodyContext, HTMLLinkableContext {}
     /// The context within an HTML `<audio>` element.
@@ -99,7 +99,7 @@ public extension HTML {
     /// The context within an HTML `<datalist>` element.
     enum DataListContext: HTMLOptionListContext {}
     /// The context within an HTML `<dl>` element.
-    enum DescriptionListContext: HTMLStylableContext {}
+    enum DescriptionListContext: HTMLStylableContext, HTMLDividableContext {}
     /// The context within an HTML `<details>` element.
     final class DetailsContext: BodyContext {}
     /// The context within an HTML `<embed>` element.
@@ -153,6 +153,8 @@ public protocol HTMLContext {}
 /// Context shared among all HTML elements that can have their dimensions
 /// (width and height) specified through attributes, such as `<video>`.
 public protocol HTMLDimensionContext: HTMLContext {}
+/// Context shared among all HTML elements can be divided using `<div>` elements.
+public protocol HTMLDividableContext: HTMLContext {}
 /// Context shared among all HTML elements that can contain an `<img>` element.
 public protocol HTMLImageContainerContext: HTMLContext {}
 /// Context shared among all HTML elements that act as some form

--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -131,7 +131,7 @@ public enum ElementDefinitions {
     /// Definition for the `<button>` element.
     public enum Button: ElementDefinition { public static var wrapper = Node.button }
     /// Definition for the `<div>` element.
-    public enum Div: ElementDefinition { public static var wrapper = Node.div }
+    public enum Div: ElementDefinition { public static var wrapper = Node<HTML.BodyContext>.div }
     /// Definition for the `<fieldset>` element.
     public enum FieldSet: ElementDefinition { public static var wrapper = Node.fieldset }
     /// Definition for the `<footer>` element.

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -173,12 +173,6 @@ public extension Node where Context: HTML.BodyContext {
         .element(named: "details", nodes: nodes)
     }
 
-    /// Add a `<div>` HTML element within the current context.
-    /// - parameter nodes: The element's attributes and child elements.
-    static func div(_ nodes: Node<HTML.BodyContext>...) -> Node {
-        .element(named: "div", nodes: nodes)
-    }
-
     /// Add a `<dl>` HTML element within the current context.
     /// - parameter nodes: The element's attributes and child elements.
     static func dl(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
@@ -432,17 +426,6 @@ public extension Node where Context == HTML.DescriptionListContext {
     }
 }
 
-public extension Node where Context == HTML.DescriptionListContext {
-    // The `<div>` element wraps a group, that is part of a term-description group in a description list (`<dl>` element).
-    //
-    // This is allowed according to the HTML spec: // https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
-    //
-    /// - parameter nodes: The element's attributes and child elements (`<dl>` or `<dd>` elements).
-    static func div(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
-        .element(named: "div", nodes: nodes)
-    }
-}
-
 public extension Node where Context: HTMLOptionListContext {
     /// Add an `<option>` HTML element within the current context.
     /// - parameter nodes: The element's attributes.
@@ -532,5 +515,13 @@ public extension Node where Context: HTMLScriptableContext {
     /// - parameter nodes: The element's attributes and text content.
     static func script(_ nodes: Node<HTML.ScriptContext>...) -> Node {
         .element(named: "script", nodes: nodes)
+    }
+}
+
+public extension Node where Context: HTMLDividableContext {
+    /// Add a `<div>` HTML element within the current context.
+    /// - parameter nodes: The element's attributes and child elements.
+    static func div(_ nodes: Node<Context>...) -> Node {
+        .element(named: "div", nodes: nodes)
     }
 }

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -438,7 +438,7 @@ public extension Node where Context == HTML.DescriptionListContext {
     // This is allowed according to the HTML spec: // https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
     //
     /// - parameter nodes: The element's attributes and child elements (`<dl>` or `<dd>` elements).
-    static func Div(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
+    static func div(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
         .element(named: "div", nodes: nodes)
     }
 }

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -433,12 +433,12 @@ public extension Node where Context == HTML.DescriptionListContext {
 }
 
 public extension Node where Context == HTML.DescriptionListContext {
-    /// The `<div>` element wraps a group, that is part of a term-description group in a description list (`<dl>` element).
-    ///
-    /// This is allowed according to the HTML spec: // https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
-    ///
+    // The `<div>` element wraps a group, that is part of a term-description group in a description list (`<dl>` element).
+    //
+    // This is allowed according to the HTML spec: // https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
+    //
     /// - parameter nodes: The element's attributes and child elements (`<dl>` or `<dd>` elements).
-    static func dlDiv(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
+    static func Div(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
         .element(named: "div", nodes: nodes)
     }
 }

--- a/Sources/Plot/API/HTMLElements.swift
+++ b/Sources/Plot/API/HTMLElements.swift
@@ -426,6 +426,17 @@ public extension Node where Context == HTML.DescriptionListContext {
     }
 }
 
+public extension Node where Context == HTML.DescriptionListContext {
+    /// The `<div>` element wraps a group, that is part of a term-description group in a description list (`<dl>` element).
+    ///
+    /// This is allowed according to the HTML spec: // https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
+    ///
+    /// - parameter nodes: The element's attributes and child elements (`<dl>` or `<dd>` elements).
+    static func dlDiv(_ nodes: Node<HTML.DescriptionListContext>...) -> Node {
+        .element(named: "div", nodes: nodes)
+    }
+}
+
 public extension Node where Context: HTMLOptionListContext {
     /// Add an `<option>` HTML element within the current context.
     /// - parameter nodes: The element's attributes.

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -161,8 +161,8 @@ final class HTMLComponentTests: XCTestCase {
     }
 
     func testAddingClassToNode() {
-        let html = Node.div().class("hello").render()
-        XCTAssertEqual(html, #"<div class="hello"></div>"#)
+        let html = Node.div(.p()).class("hello").render()
+        XCTAssertEqual(html, #"<div class="hello"><p></p></div>"#)
     }
 
     func testEnvironmentValuesDoNotApplyToSiblings() {

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -268,37 +268,7 @@ final class HTMLTests: XCTestCase {
         )))
 
         assertEqualHTMLContent(html, """
-        <!DOCTYPE html>
-        <html>
-            <head>
-                <title>My website</title>
-                <meta name="twitter:title" content="My website"/>
-                <meta name="og:title" content="My website"/>
-                <link rel="stylesheet" href="styles.css" type="text/css"/>
-            </head>
-            <body>
-                <div>
-                    <h1>My website</h1>
-                    <p>Writing HTML in Swift is pretty great!</p>
-                </div>
-                <dl>
-                    <div>
-                        <dt>Last modified time</dt>
-                        <dd>2004-12-23T23:33Z</dd>
-                    </div>
-                    <div>
-                        <dt>Recommended update interval</dt>
-                        <dd>60s</dd>
-                    </div>
-                    <div>
-                        <dt>Authors</dt>
-                        <dt>Editors</dt>
-                        <dd>Robert Rothman</dd>
-                        <dd>Daniel Jackson</dd>
-                    </div>
-                </dl>
-            </body>
-        </html>
+        <body><dl><div><dt>Last modified time</dt><dd>2004-12-23T23:33Z</dd></div><div><dt>Recommended update interval</dt><dd>60s</dd></div><div><dt>Authors</dt><dt>Editors</dt><dd>Robert Rothman</dd><dd>Daniel Jackson</dd></div></dl></body>
         """)
     }
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -248,6 +248,59 @@ final class HTMLTests: XCTestCase {
         <body><dl><dt>Term</dt><dd>Description</dd></dl></body>
         """)
     }
+    
+    func testDescriptionListWithDiv() {
+        let html = HTML(.body(.dl(
+            .dlDiv(
+                .dt("Last modified time"),
+                .dd("2004-12-23T23:33Z")
+            ),
+            .dlDiv(
+                .dt("Recommended update interval"),
+                .dd("60s")
+            ),
+            .dlDiv(
+                .dt("Authors"),
+                .dt("Editors"),
+                .dd("Robert Rothman"),
+                .dd("Daniel Jackson")
+            )
+        )))
+
+        assertEqualHTMLContent(html, """
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>My website</title>
+                <meta name="twitter:title" content="My website"/>
+                <meta name="og:title" content="My website"/>
+                <link rel="stylesheet" href="styles.css" type="text/css"/>
+            </head>
+            <body>
+                <div>
+                    <h1>My website</h1>
+                    <p>Writing HTML in Swift is pretty great!</p>
+                </div>
+                <dl>
+                    <div>
+                        <dt>Last modified time</dt>
+                        <dd>2004-12-23T23:33Z</dd>
+                    </div>
+                    <div>
+                        <dt>Recommended update interval</dt>
+                        <dd>60s</dd>
+                    </div>
+                    <div>
+                        <dt>Authors</dt>
+                        <dt>Editors</dt>
+                        <dd>Robert Rothman</dd>
+                        <dd>Daniel Jackson</dd>
+                    </div>
+                </dl>
+            </body>
+        </html>
+        """)
+    }
 
     func testAnchors() throws {
         let html = try HTML(.body(

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -273,15 +273,15 @@ final class HTMLTests: XCTestCase {
     
     func testDescriptionListWithDiv() {
         let html = HTML(.body(.dl(
-            .dlDiv(
+            .div(
                 .dt("Last modified time"),
                 .dd("2004-12-23T23:33Z")
             ),
-            .dlDiv(
+            .div(
                 .dt("Recommended update interval"),
                 .dd("60s")
             ),
-            .dlDiv(
+            .div(
                 .dt("Authors"),
                 .dt("Editors"),
                 .dd("Robert Rothman"),


### PR DESCRIPTION
According to the HTML spec: // https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
> The `<div>` element wraps a group, that is part of a term-description group in a description list (`<dl>` element).

The proposed solution (using `dlDiv` instead of `div`) is a workaround for the current requirement for `ElementDefinition`.