### PR TITLE
Add twitter:site meta tag

### DIFF
--- a/Sources/Plot/API/HTMLComponents.swift
+++ b/Sources/Plot/API/HTMLComponents.swift
@@ -81,6 +81,13 @@ public extension Node where Context == HTML.HeadContext {
     static func twitterCardType(_ type: TwitterCardType) -> Node {
         .meta(.name("twitter:card"), .content(type.rawValue))
     }
+    
+    /// Declare the Twitter handle of the site that Twitter should use when displaying a link
+    /// - parameter handle: The handle of the account on Twitter. For example: `@SwiftBySundell`
+    static func twitterUsername(_ username: String) -> Node {
+        .meta(.name("twitter:site"), .content(username))
+    }
+
 
     /// Declare how the page should behave in terms of viewport responsiveness.
     /// This declaration is important when building HTML pages for display on

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -88,7 +88,8 @@ final class HTMLTests: XCTestCase {
     func testSocialImageMetadata() {
         let html = HTML(.head(
             .socialImageLink("url.png"),
-            .twitterCardType(.summaryLargeImage)
+            .twitterCardType(.summaryLargeImage),
+            .twitterUsername("@CreatorHandle")
         ))
 
         assertEqualHTMLContent(html, """
@@ -96,6 +97,7 @@ final class HTMLTests: XCTestCase {
         <meta name="twitter:image" content="url.png"/>\
         <meta name="og:image" content="url.png"/>\
         <meta name="twitter:card" content="summary_large_image"/>\
+        <meta name="twitter:site" content="@CreatorHandle"/>\
         </head>
         """)
     }


### PR DESCRIPTION
Hi all,
This change is quite simple but something that is quite nice to have.

The tag twitter:site is used to identify the site by its Twitter handle (for example the @ SwiftBySundell twitter account) when shown in a card. See the [documentation](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup)

I added a new node .twitterUsername(_) to set the Twitter username to be associated with the page.

(This is a replacement for #85 as that one was messed up with what commits were included)