### PR TITLE
Addresses DateFormatter.timeZone setter crash when running Publish

### DIFF
--- a/Sources/Plot/API/RSS.swift
+++ b/Sources/Plot/API/RSS.swift
@@ -72,12 +72,12 @@ public protocol RSSContentContext {}
 public protocol RSSItemContext: RSSContentContext {}
 
 internal extension RSS {
-    static let dateFormatter: DateFormatter = {
+    static var dateFormatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = "E, d MMM yyyy HH:mm:ss Z"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter
-    }()
+    }
 }
 
 internal extension Document where Format: RSSBasedDocumentFormat {


### PR DESCRIPTION
We were experiencing random crashes on Linux when generating our website. I don't have the backtrace readily available, but it was clear that the crash was on the setter for `DateFormatter.timeZone` while generating a podcast feed, when generating the `lastBuildDate` and `pubDate` tags.

The crash was a bad pointer dereference and would happen randomly, which made me think it could be a concurrency-related issue. Looking into how Plot implements those tags, it uses `RSS.dateFormatter`, which was a `static let` property. This meant that it could be attempting to get and/or set the `timeZone` on the same `DateFormatter` instance from multiple threads, which would eventually lead to this crash.

The solution I came up with was to just change `RSS.dateFormatter` to a computed property, so that it's not possible for multiple threads to be using the same instance. I haven't been able to reproduce the crash again since making this change.

I believe this affected us because we're using a customized version of Publish which allows for multiple podcast feeds to be generated on the same site, and since Publish makes heavy use of concurrency, we were hit with this bug when multiple feeds were being generated at the same time.