### PR TITLE
Escape rendered attribute values

### DIFF
--- a/Sources/Plot/API/Attribute.swift
+++ b/Sources/Plot/API/Attribute.swift
@@ -68,6 +68,6 @@ extension Attribute: AnyAttribute {
             return ignoreIfValueIsEmpty ? "" : name
         }
 
-        return "\(name)=\"\(value)\""
+        return "\(name)=\"\(value.escapedForAttribute())\""
     }
 }

--- a/Sources/Plot/Internal/String+Escaping.swift
+++ b/Sources/Plot/Internal/String+Escaping.swift
@@ -5,6 +5,11 @@
 */
 
 internal extension String {
+    func escapedForAttribute() -> String {
+        escaped().replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
     func escaped() -> String {
         var pendingAmpersandString: String?
 

--- a/Tests/PlotTests/HTMLTests.swift
+++ b/Tests/PlotTests/HTMLTests.swift
@@ -967,7 +967,7 @@ final class HTMLTests: XCTestCase {
             )
         )
         assertEqualHTMLContent(html, """
-        <body><div onclick="javascript:alert('Hello World')"></div></body>
+        <body><div onclick="javascript:alert(&#39;Hello World&#39;)"></div></body>
         """)
     }
 }

--- a/Tests/PlotTests/NodeTests.swift
+++ b/Tests/PlotTests/NodeTests.swift
@@ -48,6 +48,42 @@ final class NodeTests: XCTestCase {
         XCTAssertEqual(node.render(), #"key="value""#)
     }
 
+    func testEscapingDoubleQuotesInAttributeValue() {
+        let node = Node<Any>.attribute(named: "key", value: #"a"b"#)
+        XCTAssertEqual(node.render(), #"key="a&quot;b""#)
+    }
+
+    func testEscapingSingleQuotesInAttributeValue() {
+        let node = Node<Any>.attribute(named: "key", value: "a'b")
+        XCTAssertEqual(node.render(), #"key="a&#39;b""#)
+    }
+
+    func testEscapingAngleBracketsInAttributeValue() {
+        let node = Node<Any>.attribute(named: "key", value: "<script>alert(1)</script>")
+        XCTAssertEqual(node.render(), #"key="&lt;script&gt;alert(1)&lt;/script&gt;""#)
+    }
+
+    func testEscapingAmpersandInAttributeValue() {
+        let node = Node<Any>.attribute(named: "key", value: "a&b")
+        XCTAssertEqual(node.render(), #"key="a&amp;b""#)
+    }
+
+    func testNotDoubleEscapingAttributeValue() {
+        let node = Node<Any>.attribute(named: "key", value: "&amp;")
+        XCTAssertEqual(node.render(), #"key="&amp;""#)
+    }
+
+    func testEscapingXSSInAttributeValue() {
+        let node = Node<Any>.attribute(
+            named: "value",
+            value: #""><img src=x onerror=alert(1)><input value=""#
+        )
+        XCTAssertEqual(
+            node.render(),
+            #"value="&quot;&gt;&lt;img src=x onerror=alert(1)&gt;&lt;input value=&quot;""#
+        )
+    }
+
     func testCustomElementWithCustomAttribute() {
         let node = Node<Any>.element(named: "custom", attributes: [
             Attribute(name: "key", value: "value")


### PR DESCRIPTION
This PR adds escaping of single and double quotes in attribute values, ensuring that such characters do not invalidate the HTML.

I encountered this issue when asking Claude Code to perform a security review of my app, which uses `JohnSundell/Plot`. The changes were generated by Claude Code, but I have reviewed them and believe they are sound.